### PR TITLE
Add get attribute type function in utils

### DIFF
--- a/qc_openscenario/checks/models.py
+++ b/qc_openscenario/checks/models.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from lxml import etree
 from typing import Union
+from enum import Enum
 
 from qc_baselib import Configuration, Result
 
@@ -12,3 +13,9 @@ class CheckerData:
     result: Result
     schema_version: str
     xodr_root: Union[None, etree._ElementTree]
+
+
+class AttributeType(Enum):
+    VALUE = 0
+    EXPRESSION = 1
+    PARAMETER = 2

--- a/qc_openscenario/checks/parameters_checker/valid_parameter_declaration_in_catalogs.py
+++ b/qc_openscenario/checks/parameters_checker/valid_parameter_declaration_in_catalogs.py
@@ -99,7 +99,7 @@ def check_rule(checker_data: models.CheckerData) -> None:
             for attr_name, attr_value in node_with_parameter_attribute.attrib.items():
                 if (
                     utils.get_attribute_type(attr_value)
-                    == utils.AttributeType.PARAMETER
+                    == models.AttributeType.PARAMETER
                     and attr_value[1:] not in defined_parameters_with_default
                 ):
 

--- a/qc_openscenario/checks/parameters_checker/valid_parameter_declaration_in_catalogs.py
+++ b/qc_openscenario/checks/parameters_checker/valid_parameter_declaration_in_catalogs.py
@@ -98,7 +98,8 @@ def check_rule(checker_data: models.CheckerData) -> None:
 
             for attr_name, attr_value in node_with_parameter_attribute.attrib.items():
                 if (
-                    attr_value.startswith("$")
+                    utils.get_attribute_type(attr_value)
+                    == utils.AttributeType.PARAMETER
                     and attr_value[1:] not in defined_parameters_with_default
                 ):
 

--- a/qc_openscenario/checks/reference_checker/resolvable_entity_references.py
+++ b/qc_openscenario/checks/reference_checker/resolvable_entity_references.py
@@ -89,7 +89,7 @@ def check_rule(checker_data: models.CheckerData) -> None:
         # Check if entityRef points to a declared param
         if (
             utils.get_attribute_type(current_entity_ref)
-            == utils.AttributeType.PARAMETER
+            == models.AttributeType.PARAMETER
         ):
             current_entity_param_name = current_entity_ref[1:]
             current_entity_param_value = utils.get_parameter_value(

--- a/qc_openscenario/checks/reference_checker/resolvable_entity_references.py
+++ b/qc_openscenario/checks/reference_checker/resolvable_entity_references.py
@@ -87,7 +87,10 @@ def check_rule(checker_data: models.CheckerData) -> None:
         has_issue = False
 
         # Check if entityRef points to a declared param
-        if current_entity_ref.startswith("$"):
+        if (
+            utils.get_attribute_type(current_entity_ref)
+            == utils.AttributeType.PARAMETER
+        ):
             current_entity_param_name = current_entity_ref[1:]
             current_entity_param_value = utils.get_parameter_value(
                 root, current_entity_param_name

--- a/qc_openscenario/checks/utils.py
+++ b/qc_openscenario/checks/utils.py
@@ -1,16 +1,10 @@
 from lxml import etree
 from typing import Union
-from enum import Enum
+from qc_openscenario.checks import models
 import re
 
 EXPRESSION_PATTERN = re.compile("[$][{][ A-Za-z0-9_\+\-\*/%$\(\)\.,]*[\}]")
 PARAMETER_PATTERN = re.compile("[$][A-Za-z_][A-Za-z0-9_]*")
-
-
-class AttributeType(Enum):
-    STRING = 0
-    EXPRESSION = 1
-    PARAMETER = 2
 
 
 def get_standard_schema_version(root: etree._ElementTree) -> Union[str, None]:
@@ -104,7 +98,7 @@ def get_xodr_road_network(root: etree._ElementTree) -> Union[etree._ElementTree,
         return None
 
     # If filepath is specified using param, get all param declaration and update the filepath
-    if get_attribute_type(filepath) == AttributeType.PARAMETER:
+    if get_attribute_type(filepath) == models.AttributeType.PARAMETER:
         filepath_param = filepath[1:]
         filepath = get_parameter_value(root, filepath_param)
         if filepath is None:
@@ -113,22 +107,22 @@ def get_xodr_road_network(root: etree._ElementTree) -> Union[etree._ElementTree,
     return etree.parse(filepath)
 
 
-def get_attribute_type(attribute_value: str) -> AttributeType:
+def get_attribute_type(attribute_value: str) -> models.AttributeType:
     """Given attribute value as input, checks if it is an expression, a parameter or a plain string
 
     Args:
         attribute_value (str): the attribute value to check
 
     Returns:
-        AttributeType: enum representing whether attribute value is
+        models.AttributeType: enum representing whether attribute value is
             - expression (AttributeType.EXPRESSION),
             - parameter (AttributeType.PARAMETER)
             - a plain string (AttributeType.STRING)
     """
 
     if EXPRESSION_PATTERN.match(attribute_value):
-        return AttributeType.EXPRESSION
+        return models.AttributeType.EXPRESSION
     elif PARAMETER_PATTERN.match(attribute_value):
-        return AttributeType.PARAMETER
+        return models.AttributeType.PARAMETER
 
-    return AttributeType.STRING
+    return models.AttributeType.VALUE

--- a/tests/data/parameter_declaration_with_expression/VehicleCatalog.xosc
+++ b/tests/data/parameter_declaration_with_expression/VehicleCatalog.xosc
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSCENARIO xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../Schema/OpenSCENARIO.xsd">
+  <FileHeader revMajor="1" revMinor="3" date="2020-02-21T10:00:00" description="Example - Vehicle Catalog" author="ASAM e.V." />
+  <Catalog name="VehicleCatalog">
+    <Vehicle name="car1" vehicleCategory="car">
+      <BoundingBox>
+        <Center x="1.4" y="0.0" z="0.9" />
+        <Dimensions width="2.0" length="5.0" height="1.8" />
+      </BoundingBox>
+      <Performance maxSpeed="69" maxAcceleration="200" maxDeceleration="30" />
+      <Axles>
+        <FrontAxle maxSteering="0.5235987756" wheelDiameter="0.8" trackWidth="1.68" positionX="2.98" positionZ="0.4"/>
+        <RearAxle maxSteering="0.5235987756" wheelDiameter="0.8" trackWidth="1.68" positionX="0" positionZ="0.4"/>
+      </Axles>
+    </Vehicle>
+    <Vehicle name="car2" vehicleCategory="car">
+      <BoundingBox>
+        <Center x="1.3" y="0.0" z="0.8" />
+        <Dimensions width="1.8" length="4.5" height="1.5" />
+      </BoundingBox>
+      <Performance maxSpeed="70" maxAcceleration="200" maxDeceleration="30" />
+      <Axles>
+        <FrontAxle maxSteering="0.5235987756" wheelDiameter="0.8" trackWidth="1.68" positionX="2.98" positionZ="0.4" />
+        <RearAxle maxSteering="0.5235987756" wheelDiameter="0.8" trackWidth="1.68" positionX="0" positionZ="0.4" />
+      </Axles>
+      <TrailerHitch dx="-1.2"/>
+      <Properties />
+    </Vehicle>
+    <Vehicle name="car_trailer" vehicleCategory="trailer">
+      <BoundingBox>
+          <Center x="0.87" y="0.0" z="0.61"/>
+          <Dimensions width="2.06" length="4.94" height="1.22"/>
+      </BoundingBox>
+      <Performance maxSpeed="${250/3.6}" maxDeceleration="10" maxAcceleration="5"/>
+      <Axles>
+          <RearAxle maxSteering="0.0" wheelDiameter="0.6" trackWidth="1.68" positionX="0.0" positionZ="0.3"/>
+      </Axles>
+      <TrailerCoupler dx="3.25"/>
+      <Properties/>
+    </Vehicle>
+  </Catalog>
+</OpenSCENARIO>

--- a/tests/test_basic_checks.py
+++ b/tests/test_basic_checks.py
@@ -84,3 +84,21 @@ def test_parametric_entity_ref(
 
     assert result.get_issue_count() == 0
     test_utils.cleanup_files()
+
+
+def test_parameter_declaration_with_expression(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/parameter_declaration_with_expression/"
+    target_file_name = f"VehicleCatalog.xosc"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert result.get_issue_count() == 0
+    test_utils.cleanup_files()


### PR DESCRIPTION
**Description**

While testing with the xosc examples, it was found a case in which an OpenSCENARIO expression was considered a parameter, and for that an issue was incorrectly raised:

```
        Error:      #0: Issue flagging when used parameters is not defined or has not default value within a catalog
                    Parameter value {250/3.6} for attribute maxSpeed is not defined in Catalog or has no default value
                       XPath: /OpenSCENARIO/Catalog/Vehicle[3]/Performance
```

This is now fixed with a classification function that tells whether a string is an expression, a parameter or just a plain string

**How was the PR tested?**

1. Unit-test with sample data. All unit tests passed.

**Notes**

utils test function:

```
>>> utils.get_attribute_type("TEST")
<AttributeType.VALUE: 0>
>>> utils.get_attribute_type("$TEST")
<AttributeType.PARAMETER: 2>
>>> utils.get_attribute_type("${TEST")
<AttributeType.VALUE: 0>
>>> utils.get_attribute_type("${1/3}")
<AttributeType.EXPRESSION: 1>
```
