### PR TITLE
Add scoped params filtering to parameter search

### DIFF
--- a/qc_openscenario/checks/reference_checker/resolvable_entity_references.py
+++ b/qc_openscenario/checks/reference_checker/resolvable_entity_references.py
@@ -92,8 +92,8 @@ def check_rule(checker_data: models.CheckerData) -> None:
             == models.AttributeType.PARAMETER
         ):
             current_entity_param_name = current_entity_ref[1:]
-            current_entity_param_value = utils.get_parameter_value(
-                root, current_entity_param_name
+            current_entity_param_value = utils.get_parameter_value_from_node(
+                root, node_with_entity_ref, current_entity_param_name
             )
             logging.debug(f"current_entity_param_name: {current_entity_param_name}")
             logging.debug(f"current_entity_param_value: {current_entity_param_value}")

--- a/qc_openscenario/checks/utils.py
+++ b/qc_openscenario/checks/utils.py
@@ -1,5 +1,5 @@
 from lxml import etree
-from typing import Union, Dict
+from typing import Union
 from qc_openscenario.checks import models
 import re
 


### PR DESCRIPTION
**Description**

Following [standard document reference](https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/09_reuse_mechanisms/09_01_parameters.html), now parameter search takes into account local scope and only visible parameters

**How was the PR tested?**

1. Unit-test with sample data. All unit tests passed.

**Notes**
