### PR TITLE
Add trailer connect test to improve allowed operator check

### DIFF
--- a/tests/data/allowed_operators/negative_example_multiple.xosc
+++ b/tests/data/allowed_operators/negative_example_multiple.xosc
@@ -21,7 +21,7 @@
                                     <VehicleLight vehicleLightType="${2*3+4^23}" />
                                 </LightType>
                                 <!-- Character ^ not supported in expression -->
-                                <LightState mode="${3^foo}" />
+                                <LightState mode="${3^$foo}" />
                             </LightStateAction>
                         </AppearanceAction>
                     </PrivateAction>

--- a/tests/data/parametric_operator_in_expression/TrailerConnect.xosc
+++ b/tests/data/parametric_operator_in_expression/TrailerConnect.xosc
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8"?>
+<OpenSCENARIO xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Schema/OpenSCENARIO.xsd">
+    <FileHeader revMajor="1" revMinor="3" date="2023-11-30T10:00:00" description="Demonstrate TrailerAction" author="ASAM e.V."/>
+    <ParameterDeclarations>
+        <ParameterDeclaration name="X0" parameterType="double" value="1.7"/>
+        <ParameterDeclaration name="Y0" parameterType="double" value="13.5"/>
+        <ParameterDeclaration name="TrajRadius" parameterType="double" value="12.0"/>
+        <ParameterDeclaration name="Speed" parameterType="double" value="4.0"/>
+    </ParameterDeclarations>
+    <CatalogLocations>
+        <VehicleCatalog>
+            <Directory path="Catalogs/Vehicles"/>
+        </VehicleCatalog>
+        <ControllerCatalog>
+            <Directory path="Catalogs/Controllers"/>
+        </ControllerCatalog>
+    </CatalogLocations>
+    <RoadNetwork/>
+    <Entities>
+        <ScenarioObject name="Trailer">
+            <CatalogReference catalogName="VehicleCatalog" entryName="car_trailer"/>
+        </ScenarioObject>
+        <ScenarioObject name="Car">
+            <CatalogReference catalogName="VehicleCatalog" entryName="car2"/>
+        </ScenarioObject>
+    </Entities>
+    <Storyboard>
+        <Init>
+            <Actions>
+                <Private entityRef="Trailer">
+                    <PrivateAction>
+                        <TeleportAction>
+                            <Position>
+                                <WorldPosition x="$X0" y="$Y0" z="0.0" h="1.5708" p="0.0" r="0.0"/>
+                            </Position>
+                        </TeleportAction>
+                    </PrivateAction>
+                </Private>
+                <Private entityRef="Car">
+                    <PrivateAction>
+                        <TeleportAction>
+                            <Position>
+                                <WorldPosition x="${$X0 - $TrajRadius}" y="${$Y0 + $TrajRadius + 4.7}" z="0.0" h="3.1415" p="0.0" r="0.0"/>
+                            </Position>
+                        </TeleportAction>
+                    </PrivateAction>
+                </Private>
+            </Actions>
+        </Init>
+        <Story name="TrailerStory">
+            <Act name="TrailerAct">
+                <ManeuverGroup maximumExecutionCount="1" name="DummyManueverGroup">
+                    <Actors selectTriggeringEntities="false">
+                        <EntityRef entityRef="Car"/>
+                    </Actors>
+                    <Maneuver name="ConnectManeuver">
+                        <Event maximumExecutionCount="1" name="ReverseEvent" priority="overwrite">
+                            <Action name="ReverseSpeedAction">
+                                <PrivateAction>
+                                    <LongitudinalAction>
+                                        <SpeedAction>
+                                            <SpeedActionDynamics dynamicsDimension="time" dynamicsShape="step" value="0"/>
+                                            <SpeedActionTarget>
+                                                <AbsoluteTargetSpeed value="${-$Speed}"/>
+                                            </SpeedActionTarget>
+                                        </SpeedAction>
+                                    </LongitudinalAction>
+                                </PrivateAction>
+                            </Action>
+                            <Action name="ReverseTrajectoryAction">
+                                <PrivateAction>
+                                    <RoutingAction>
+                                        <FollowTrajectoryAction>
+                                            <Trajectory closed="false" name="TrajectoryReverse">
+                                                <ParameterDeclarations/>
+                                                <Shape>
+                                                    <Clothoid curvature="${-1.0/$TrajRadius}" curvatureDot="0.0" length="${0.25 * 2.0 * 3.141592 * $TrajRadius}">
+                                                        <Position>
+                                                            <RelativeWorldPosition dx="0.0" dy="0.0" entityRef="Car">
+                                                                <Orientation type="relative" h="3.1415"/>
+                                                            </RelativeWorldPosition>
+                                                        </Position>
+                                                    </Clothoid>
+                                                </Shape>
+                                            </Trajectory>
+                                            <TimeReference>
+                                                <None/>
+                                            </TimeReference>
+                                            <TrajectoryFollowingMode followingMode="position"/>
+                                        </FollowTrajectoryAction>
+                                    </RoutingAction>
+                                </PrivateAction>
+                            </Action>
+                            <StartTrigger>
+                                <ConditionGroup>
+                                    <Condition name="ReverseTrigger" delay="0.0" conditionEdge="none">
+                                        <ByValueCondition>
+                                            <SimulationTimeCondition value="1.0" rule="greaterOrEqual"/>
+                                        </ByValueCondition>
+                                    </Condition>
+                                </ConditionGroup>
+                            </StartTrigger>
+                        </Event>
+                        <Event maximumExecutionCount="1" name="ConnectEvent" priority="overwrite">
+                            <Action name="ConnectAction">
+                                <PrivateAction>
+                                    <TrailerAction>
+                                        <ConnectTrailerAction trailerRef="Trailer"/>
+                                    </TrailerAction>
+                                </PrivateAction>
+                            </Action>
+                            <StartTrigger>
+                                <ConditionGroup>
+                                    <Condition name="ConnectTrigger" delay="2.0" conditionEdge="rising">
+                                        <ByValueCondition>
+                                            <StoryboardElementStateCondition storyboardElementType="event" storyboardElementRef="ReverseEvent" state="endTransition"/>
+                                        </ByValueCondition>
+                                    </Condition>
+                                </ConditionGroup>
+                            </StartTrigger>
+                        </Event>
+                        <Event maximumExecutionCount="1" name="ForwardEvent" priority="overwrite">
+                            <Action name="ForwardSpeedAction">
+                                <PrivateAction>
+                                    <LongitudinalAction>
+                                        <SpeedAction>
+                                            <SpeedActionDynamics dynamicsDimension="time" dynamicsShape="step" value="0"/>
+                                            <SpeedActionTarget>
+                                                <AbsoluteTargetSpeed value="$Speed"/>
+                                            </SpeedActionTarget>
+                                        </SpeedAction>
+                                    </LongitudinalAction>
+                                </PrivateAction>
+                            </Action>
+                            <Action name="ForwardTrajectoryAction">
+                                <PrivateAction>
+                                    <RoutingAction>
+                                        <FollowTrajectoryAction>
+                                            <Trajectory closed="false" name="TrajectoryReverse">
+                                                <ParameterDeclarations/>
+                                                <Shape>
+                                                    <Clothoid curvature="${-1.0/$TrajRadius}" curvatureDot="0.001" length="25.0">
+                                                        <Position>
+                                                            <RelativeWorldPosition dx="0.0" dy="0.0" entityRef="Car">
+                                                                <Orientation type="relative" h="0.0"/>
+                                                            </RelativeWorldPosition>
+                                                        </Position>
+                                                    </Clothoid>
+                                                </Shape>
+                                            </Trajectory>
+                                            <TimeReference>
+                                                <None/>
+                                            </TimeReference>
+                                            <TrajectoryFollowingMode followingMode="position"/>
+                                        </FollowTrajectoryAction>
+                                    </RoutingAction>
+                                </PrivateAction>
+                            </Action>
+                            <StartTrigger>
+                                <ConditionGroup>
+                                    <Condition name="ForwardEventCondition" delay="2.0" conditionEdge="rising">
+                                        <ByValueCondition>
+                                            <StoryboardElementStateCondition storyboardElementType="event" storyboardElementRef="ConnectEvent" state="endTransition"/>
+                                        </ByValueCondition>
+                                    </Condition>
+                                </ConditionGroup>
+                            </StartTrigger>
+                        </Event>
+                        <Event maximumExecutionCount="1" name="DisconnectEvent" priority="parallel">
+                            <Action name="DisconnectAction">
+                                <PrivateAction>
+                                    <TrailerAction>
+                                        <DisconnectTrailerAction/>
+                                    </TrailerAction>
+                                </PrivateAction>
+                            </Action>
+                            <StartTrigger>
+                                <ConditionGroup>
+                                    <Condition name="DisconnectEventCondition" delay="4.0" conditionEdge="rising">
+                                        <ByValueCondition>
+                                            <StoryboardElementStateCondition storyboardElementType="event" storyboardElementRef="ForwardEvent" state="startTransition"/>
+                                        </ByValueCondition>
+                                    </Condition>
+                                </ConditionGroup>
+                            </StartTrigger>
+                        </Event>
+                    </Maneuver>
+                </ManeuverGroup>
+                <StartTrigger>
+                    <ConditionGroup>
+                        <Condition name="StartTrigger" delay="0" conditionEdge="none">
+                            <ByValueCondition>
+                                <SimulationTimeCondition value="2" rule="greaterOrEqual"/>
+                            </ByValueCondition>
+                        </Condition>
+                    </ConditionGroup>
+                </StartTrigger>
+            </Act>
+        </Story>
+        <StopTrigger>
+            <ConditionGroup>
+                <Condition name="StopCondition" delay="2.0" conditionEdge="rising">
+                    <ByValueCondition>
+                        <StoryboardElementStateCondition storyboardElementType="event" storyboardElementRef="ForwardEvent" state="endTransition"/>
+                    </ByValueCondition>
+                </Condition>
+            </ConditionGroup>
+        </StopTrigger>
+    </Storyboard>
+</OpenSCENARIO>

--- a/tests/test_data_type_checks.py
+++ b/tests/test_data_type_checks.py
@@ -190,6 +190,32 @@ def test_allowed_operators_positive_multiple(
     test_utils.cleanup_files()
 
 
+def test_trailer_connect_standard_example(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/parametric_operator_in_expression/"
+    target_file_name = f"TrailerConnect.xosc"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        len(
+            result.get_issues_by_rule_uid(
+                "asam.net:xosc:1.2.0:data_type.allowed_operators"
+            )
+        )
+        == 0
+    )
+
+    test_utils.cleanup_files()
+
+
 def test_allowed_operators_negative(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
**Description**

With the execution of all osc checkers on standard examples, it emerged a problem with `TrailerConnect.xosc`

```
 Summary:        
        Error:      #0: Issue flagging invalid operand is used within expression
                    Invalid operand -$Speed used
        Error:      #1: Issue flagging invalid operand is used within expression
                    Invalid operand /$TrajRadius used
        Error:      #2: Issue flagging invalid operand is used within expression
                    Invalid operand /$TrajRadius used
```

The expression parsing needed to be fixed to treat variables as such

Fixed also a typo in one negative example that was causing one issue more to be triggered

**How was the PR tested?**

1. Unit-test with  sample data. All unit tests passed.
2. Added specific test for the case arisen. OK.

**Notes**
