### PR TITLE
Check input string before double conversion in non negative checks

### DIFF
--- a/qc_openscenario/checks/data_type_checker/non_negative_transition_time_in_light_state_action.py
+++ b/qc_openscenario/checks/data_type_checker/non_negative_transition_time_in_light_state_action.py
@@ -94,6 +94,12 @@ def check_rule(checker_data: models.CheckerData) -> None:
             continue
 
         logging.debug(f"current_transition_time: {current_transition_time}")
+        if not utils.is_xsd_double(current_transition_time):
+            logging.error(
+                f"Cannot convert '{current_transition_time}' to double as it does not match xsd:double pattern. Skipping check..."
+            )
+            return
+
         current_numeric_value = float(current_transition_time)
         has_issue = current_numeric_value < 0
 

--- a/qc_openscenario/checks/data_type_checker/positive_duration_in_phase.py
+++ b/qc_openscenario/checks/data_type_checker/positive_duration_in_phase.py
@@ -85,6 +85,12 @@ def check_rule(checker_data: models.CheckerData) -> None:
                 continue
             current_duration = current_duration_param_value
 
+        if not utils.is_xsd_double(current_duration):
+            logging.error(
+                f"Cannot convert '{current_duration}' to double as it does not match xsd:double pattern. Skipping check..."
+            )
+            return
+
         current_numeric_value = float(current_duration)
         has_issue = current_numeric_value < 0
 

--- a/qc_openscenario/checks/utils.py
+++ b/qc_openscenario/checks/utils.py
@@ -132,3 +132,17 @@ def get_attribute_type(attribute_value: str) -> models.AttributeType:
         return models.AttributeType.PARAMETER
 
     return models.AttributeType.VALUE
+
+
+def is_xsd_double(input_str: str) -> bool:
+    """Checks if input string follows xsd double specification
+    The pattern is built following xsd double definition from http://www.datypic.com/sc/xsd/t-xsd_double.html
+
+    Args:
+        input_str (str): The input string to check
+
+    Returns:
+        bool: True if the input string represent a valid xsd:double value. False otherwise
+    """
+    pattern = re.compile(r"^([+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?|INF|-INF|NaN)$")
+    return pattern.match(input_str) is not None


### PR DESCRIPTION
**Description**

Check input string before double conversion in non negative checks

This PR follows the test on public openscenario example where reading the value "1,2" was crashing the checker execution

Now it skips the checks as the value sign cannot be interpreted if the double string is not well formed

**How was the PR tested?**

1. Unit-test with  sample data. All unit tests passed.
**Notes**
