### PR TITLE
Update xml file parse to ignore namespace

### DIFF
--- a/qc_openscenario/checks/basic_checker/basic_checker.py
+++ b/qc_openscenario/checks/basic_checker/basic_checker.py
@@ -41,7 +41,7 @@ def run_checks(config: Configuration, result: Result) -> models.CheckerData:
 
     else:
         input_file_path = config.get_config_param("InputFile")
-        root = etree.parse(input_file_path)
+        root = utils.get_root_without_default_namespace(input_file_path)
         xosc_schema_version = utils.get_standard_schema_version(root)
 
         xodr_root = utils.get_xodr_road_network(input_file_path, root)

--- a/qc_openscenario/checks/utils.py
+++ b/qc_openscenario/checks/utils.py
@@ -1,4 +1,5 @@
 from lxml import etree
+from io import BytesIO
 from typing import Union
 from qc_openscenario.checks import models
 import re
@@ -7,6 +8,16 @@ import os
 
 EXPRESSION_PATTERN = re.compile(r"[$][{][ A-Za-z0-9_\+\-\*/%$\(\)\.,]*[\}]")
 PARAMETER_PATTERN = re.compile(r"[$][A-Za-z_][A-Za-z0-9_]*")
+
+
+def get_root_without_default_namespace(path: str) -> etree._ElementTree:
+    with open(path, "rb") as raw_file:
+        xml_string = raw_file.read().decode()
+
+        if "xmlns" in xml_string:
+            xml_string = re.sub(' xmlns="[^"]+"', "", xml_string)
+
+        return etree.parse(BytesIO(xml_string.encode()))
 
 
 def get_standard_schema_version(root: etree._ElementTree) -> Union[str, None]:
@@ -117,7 +128,7 @@ def get_xodr_road_network(
     previous_wd = os.getcwd()
     os.chdir(os.path.dirname(input_file_path))
 
-    xodr_root = etree.parse(filepath)
+    xodr_root = get_root_without_default_namespace(filepath)
 
     os.chdir(previous_wd)
 


### PR DESCRIPTION
**Description**

This PR adds a method to get root of OpenScenario files using default namespace in case namespace is provided.

**Main changes**

1. Add helper function to get xml root file with default namespace
2. Update functions that get root to use new helper function

**How was the PR tested?**

1. Unit-test are passing as expected.

**Notes**
- None.