### PR TITLE
Add checker bundle automatically generated doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ htmlcov
 coverage.xml
 .coverage*
 .python-version
+generated_checker_bundle_doc.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # qc-openscenarioxml
 
-This project implements the OpenScenario Checker for the ASAM Quality Checker project.
+This project implements the [ASAM OpenScenario XML Checker](checker_bundle_doc.md) for the ASAM Quality Checker project.
 
 ## Installation
 

--- a/checker_bundle_doc.md
+++ b/checker_bundle_doc.md
@@ -1,0 +1,49 @@
+# Checker bundle: xoscBundle
+
+* Build version:  0.1.0
+* Description:    ASAM OpenScenario XML checker bundle
+
+## Parameters
+
+* InputFile: The path of the input file.
+
+## Checkers
+
+### basic_xosc
+
+* Description: Check if basic properties of input file are properly set
+* Addressed rules:
+  * asam.net:xosc:1.0.0:xml.valid_xml_document
+
+### schema_xosc
+
+* Description: Check if xml properties of input file are properly set
+* Addressed rules:
+  * asam.net:xosc:1.0.0:xml.valid_schema
+
+### reference_xosc
+
+* Description: Check if xml properties of input file are properly set
+* Addressed rules:
+  * asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+  * asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+  * asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+  * asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+  * asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+  * asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+  * asam.net:xosc:1.2.0:reference_control.resolvable_storyboard_element_reference
+  * asam.net:xosc:1.2.0:reference_control.unique_element_names_on_same_level
+
+### parameters_xosc
+
+* Description: Check if parameters properties of input file are properly set
+* Addressed rules:
+  * asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+### data_type_xosc
+
+* Description: Check if data_type properties of input file are properly set
+* Addressed rules:
+  * asam.net:xosc:1.2.0:data_type.allowed_operators
+  * asam.net:xosc:1.2.0:data_type.non_negative_transition_time_in_light_state_action
+  * asam.net:xosc:1.2.0:data_type.positive_duration_in_phase

--- a/qc_openscenario/main.py
+++ b/qc_openscenario/main.py
@@ -75,6 +75,9 @@ def main():
             )
         )
 
+        # Uncomment the follow line to generate the checker bundle documentation.
+        # result.write_markdown_doc("checker_bundle_doc.md")
+
     logging.info("Done")
 
 

--- a/qc_openscenario/main.py
+++ b/qc_openscenario/main.py
@@ -25,6 +25,8 @@ def args_entrypoint() -> argparse.Namespace:
     group.add_argument("-d", "--default_config", action="store_true")
     group.add_argument("-c", "--config_path")
 
+    parser.add_argument("-g", "--generate_markdown", action="store_true")
+
     return parser.parse_args()
 
 
@@ -75,8 +77,8 @@ def main():
             )
         )
 
-        # Uncomment the follow line to generate the checker bundle documentation.
-        # result.write_markdown_doc("checker_bundle_doc.md")
+        if args.generate_markdown:
+            result.write_markdown_doc("generated_checker_bundle_doc.md")
 
     logging.info("Done")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,11 +28,7 @@ def launch_main(monkeypatch):
     monkeypatch.setattr(
         sys,
         "argv",
-        [
-            "main.py",
-            "-c",
-            CONFIG_FILE_PATH,
-        ],
+        ["main.py", "-c", CONFIG_FILE_PATH, "--generate_markdown"],
     )
     main.main()
 


### PR DESCRIPTION
**Description**

Add checker bundle doc using the automatically generated documentation supported in the baselib.

**Main changes**

1. Add an option to generate the documentation.
2. Add and link the generated documentation to README.md

**How was the PR tested?**

1. Render the generated documentation.

**Notes**

Related issue: https://github.com/asam-ev/qc-framework/issues/27