### PR TITLE
Use resource to access schema files

### DIFF
--- a/qc_openscenario/checks/schema_checker/valid_schema.py
+++ b/qc_openscenario/checks/schema_checker/valid_schema.py
@@ -1,3 +1,4 @@
+import importlib.resources
 import os, logging
 
 from dataclasses import dataclass
@@ -68,8 +69,9 @@ def check_rule(checker_data: models.CheckerData) -> None:
     schema_files_dict = schema_files.SCHEMA_FILES
 
     xsd_file = schema_files_dict[schema_version]
-    xsd_file_path = os.path.join("qc_openscenario", "schema", xsd_file)
-
+    xsd_file_path = str(
+        importlib.resources.files("qc_openscenario.schema").joinpath(xsd_file)
+    )
     schema_compliant, errors = _is_schema_compliant(
         checker_data.input_file_xml_root, xsd_file_path
     )


### PR DESCRIPTION
**Description**

Before, schema files were accessed using relative paths. It doesn't work when we distribute the package via pip.

Now, schema files were accessed as package resources.

**Main changes**

1. Use package resource to access schema files.

**How was the PR tested?**

1. Unit-test and tested via a local demo pipeline build and run.

**Notes**
