### PR TITLE
Refactor to use one checker per rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,15 +131,27 @@ An example configuration file for using this Checker Bundle within the ASAM Qual
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Config>
 
-    <Param name="InputFile" value="template.xosc" />
+    <Param name="InputFile" value="my_openscenarioxml_file.xosc" />
 
     <CheckerBundle application="xoscBundle">
         <Param name="resultFile" value="xosc_bundle_report.xqar" />
-        <Checker checkerId="basic_xosc" maxLevel="1" minLevel="3" />
-        <Checker checkerId="schema_xosc" maxLevel="1" minLevel="3" />
-        <Checker checkerId="data_type_xosc" maxLevel="1" minLevel="3" />
-        <Checker checkerId="parameters_xosc" maxLevel="1" minLevel="3" />
-        <Checker checkerId="reference_xosc" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_xml_valid_xml_document" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_xml_root_tag_is_openscenario" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_xml_fileheader_is_present" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_xml_version_is_defined" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_xml_valid_schema" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_reference_control_uniquely_resolvable_entity_references" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_reference_control_resolvable_signal_id_in_traffic_signal_state_action" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_reference_control_resolvable_traffic_signal_controller_by_traffic_signal_controller_ref" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_reference_control_valid_actor_reference_in_private_actions" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_reference_control_resolvable_entity_references" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_reference_control_resolvable_variable_reference" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_reference_control_resolvable_storyboard_element_reference" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_reference_control_unique_element_names_on_same_level" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_parameters_valid_parameter_declaration_in_catalogs" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_data_type_allowed_operators" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_data_type_non_negative_transition_time_in_light_state_action" maxLevel="1" minLevel="3" />
+        <Checker checkerId="check_asam_xosc_positive_duration_in_phase" maxLevel="1" minLevel="3" />
     </CheckerBundle>
 
     <ReportModule application="TextReport">

--- a/checker_bundle_doc.md
+++ b/checker_bundle_doc.md
@@ -1,49 +1,112 @@
 # Checker bundle: xoscBundle
 
 * Build version:  0.1.0
-* Description:    ASAM OpenScenario XML checker bundle
+* Description:    OpenScenario checker bundle
 
 ## Parameters
 
-* InputFile: The path of the input file.
+* InputFile
 
 ## Checkers
 
-### basic_xosc
+### check_asam_xosc_xml_valid_xml_document
 
-* Description: Check if basic properties of input file are properly set
+* Description: The given file to check must be a valid XML document.
 * Addressed rules:
   * asam.net:xosc:1.0.0:xml.valid_xml_document
 
-### schema_xosc
+### check_asam_xosc_xml_root_tag_is_openscenario
 
-* Description: Check if xml properties of input file are properly set
+* Description: The root element of a valid XML document must be OpenSCENARIO.
+* Addressed rules:
+  * asam.net:xosc:1.0.0:xml.root_tag_is_openscenario
+
+### check_asam_xosc_xml_fileheader_is_present
+
+* Description: Below the root element a tag with FileHeader must be defined.
+* Addressed rules:
+  * asam.net:xosc:1.0.0:xml.fileheader_is_present
+
+### check_asam_xosc_xml_version_is_defined
+
+* Description: The FileHeader tag must have the attributes revMajor and revMinor and of type unsignedShort.
+* Addressed rules:
+  * asam.net:xosc:1.0.0:xml.version_is_defined
+
+### check_asam_xosc_xml_valid_schema
+
+* Description: Input xml file must be valid according to the schema.
 * Addressed rules:
   * asam.net:xosc:1.0.0:xml.valid_schema
 
-### reference_xosc
+### check_asam_xosc_reference_control_uniquely_resolvable_entity_references
 
-* Description: Check if xml properties of input file are properly set
+* Description: Input xml file must be valid according to the schema.
 * Addressed rules:
   * asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+### check_asam_xosc_reference_control_resolvable_signal_id_in_traffic_signal_state_action
+
+* Description: TrafficSignalStateAction:name -> Signal ID must exist within the given road network.
+* Addressed rules:
   * asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+### check_asam_xosc_reference_control_resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+* Description: The trafficSignalController according to the trafficSignalControllerRef property must exist within the scenarios RoadNetwork definition.
+* Addressed rules:
   * asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+### check_asam_xosc_reference_control_valid_actor_reference_in_private_actions
+
+* Description: In a ManeuverGroup, if the defined action is a private action an actor must be defined.
+* Addressed rules:
   * asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+### check_asam_xosc_reference_control_resolvable_entity_references
+
+* Description: A named reference in the EntityRef must be resolvable.
+* Addressed rules:
   * asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+### check_asam_xosc_reference_control_resolvable_variable_reference
+
+* Description: The VariableDeclaration according to the variableRef property must exist within the ScenarioDefinition.
+* Addressed rules:
   * asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+### check_asam_xosc_reference_control_resolvable_storyboard_element_reference
+
+* Description: The attribute storyboardElementRef shall point to an existing element of the corresponding type and shall be uniquely resolvable.
+* Addressed rules:
   * asam.net:xosc:1.2.0:reference_control.resolvable_storyboard_element_reference
+
+### check_asam_xosc_reference_control_unique_element_names_on_same_level
+
+* Description: Element names at each level shall be unique at that level.
+* Addressed rules:
   * asam.net:xosc:1.2.0:reference_control.unique_element_names_on_same_level
 
-### parameters_xosc
+### check_asam_xosc_parameters_valid_parameter_declaration_in_catalogs
 
-* Description: Check if parameters properties of input file are properly set
+* Description: All parameters used within a catalog shall be declared within their ParameterDeclaration in the same catalog, which sets a default value for each parameter.
 * Addressed rules:
   * asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
 
-### data_type_xosc
+### check_asam_xosc_data_type_allowed_operators
 
-* Description: Check if data_type properties of input file are properly set
+* Description: Expressions in OpenSCENARIO must only use the allowed operands.
 * Addressed rules:
   * asam.net:xosc:1.2.0:data_type.allowed_operators
+
+### check_asam_xosc_data_type_non_negative_transition_time_in_light_state_action
+
+* Description: Expressions in OpenSCENARIO must only use the allowed operands.
+* Addressed rules:
   * asam.net:xosc:1.2.0:data_type.non_negative_transition_time_in_light_state_action
+
+### check_asam_xosc_positive_duration_in_phase
+
+* Description: Expressions in OpenSCENARIO must only use the allowed operands.
+* Addressed rules:
   * asam.net:xosc:1.2.0:data_type.positive_duration_in_phase

--- a/poetry.lock
+++ b/poetry.lock
@@ -29,7 +29,7 @@ pydantic-xml = "^2.11.0"
 type = "git"
 url = "https://github.com/asam-ev/qc-baselib-py.git"
 reference = "develop"
-resolved_reference = "fba6e49096d14ba31f5bf17e9e5efe6020eceb5c"
+resolved_reference = "7c1825ea7bc6ef47b66af91542ccc887cccbeeb8"
 
 [[package]]
 name = "black"
@@ -316,19 +316,19 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.2.2"
+version = "4.3.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.2.2-py3-none-any.whl", hash = "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee"},
-    {file = "platformdirs-4.2.2.tar.gz", hash = "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"},
+    {file = "platformdirs-4.3.2-py3-none-any.whl", hash = "sha256:eb1c8582560b34ed4ba105009a4badf7f6f85768b30126f351328507b2beb617"},
+    {file = "platformdirs-4.3.2.tar.gz", hash = "sha256:9e5e27a08aa095dd127b9f2e764d74254f482fef22b0970773bfba79d091ab8c"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
-type = ["mypy (>=1.8)"]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.11.2)"]
 
 [[package]]
 name = "pluggy"
@@ -347,18 +347,18 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pydantic"
-version = "2.8.2"
+version = "2.9.1"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic-2.8.2-py3-none-any.whl", hash = "sha256:73ee9fddd406dc318b885c7a2eab8a6472b68b8fb5ba8150949fc3db939f23c8"},
-    {file = "pydantic-2.8.2.tar.gz", hash = "sha256:6f62c13d067b0755ad1c21a34bdd06c0c12625a22b0fc09c6b149816604f7c2a"},
+    {file = "pydantic-2.9.1-py3-none-any.whl", hash = "sha256:7aff4db5fdf3cf573d4b3c30926a510a10e19a0774d38fc4967f78beb6deb612"},
+    {file = "pydantic-2.9.1.tar.gz", hash = "sha256:1363c7d975c7036df0db2b4a61f2e062fbc0aa5ab5f2772e0ffc7191a4f4bce2"},
 ]
 
 [package.dependencies]
-annotated-types = ">=0.4.0"
-pydantic-core = "2.20.1"
+annotated-types = ">=0.6.0"
+pydantic-core = "2.23.3"
 typing-extensions = [
     {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
     {version = ">=4.6.1", markers = "python_version < \"3.13\""},
@@ -366,103 +366,104 @@ typing-extensions = [
 
 [package.extras]
 email = ["email-validator (>=2.0.0)"]
+timezone = ["tzdata"]
 
 [[package]]
 name = "pydantic-core"
-version = "2.20.1"
+version = "2.23.3"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic_core-2.20.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3acae97ffd19bf091c72df4d726d552c473f3576409b2a7ca36b2f535ffff4a3"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41f4c96227a67a013e7de5ff8f20fb496ce573893b7f4f2707d065907bffdbd6"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f239eb799a2081495ea659d8d4a43a8f42cd1fe9ff2e7e436295c38a10c286a"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53e431da3fc53360db73eedf6f7124d1076e1b4ee4276b36fb25514544ceb4a3"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f1f62b2413c3a0e846c3b838b2ecd6c7a19ec6793b2a522745b0869e37ab5bc1"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d41e6daee2813ecceea8eda38062d69e280b39df793f5a942fa515b8ed67953"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d482efec8b7dc6bfaedc0f166b2ce349df0011f5d2f1f25537ced4cfc34fd98"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e93e1a4b4b33daed65d781a57a522ff153dcf748dee70b40c7258c5861e1768a"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e7c4ea22b6739b162c9ecaaa41d718dfad48a244909fe7ef4b54c0b530effc5a"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4f2790949cf385d985a31984907fecb3896999329103df4e4983a4a41e13e840"},
-    {file = "pydantic_core-2.20.1-cp310-none-win32.whl", hash = "sha256:5e999ba8dd90e93d57410c5e67ebb67ffcaadcea0ad973240fdfd3a135506250"},
-    {file = "pydantic_core-2.20.1-cp310-none-win_amd64.whl", hash = "sha256:512ecfbefef6dac7bc5eaaf46177b2de58cdf7acac8793fe033b24ece0b9566c"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d2a8fa9d6d6f891f3deec72f5cc668e6f66b188ab14bb1ab52422fe8e644f312"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:175873691124f3d0da55aeea1d90660a6ea7a3cfea137c38afa0a5ffabe37b88"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37eee5b638f0e0dcd18d21f59b679686bbd18917b87db0193ae36f9c23c355fc"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25e9185e2d06c16ee438ed39bf62935ec436474a6ac4f9358524220f1b236e43"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:150906b40ff188a3260cbee25380e7494ee85048584998c1e66df0c7a11c17a6"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ad4aeb3e9a97286573c03df758fc7627aecdd02f1da04516a86dc159bf70121"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3f3ed29cd9f978c604708511a1f9c2fdcb6c38b9aae36a51905b8811ee5cbf1"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b0dae11d8f5ded51699c74d9548dcc5938e0804cc8298ec0aa0da95c21fff57b"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:faa6b09ee09433b87992fb5a2859efd1c264ddc37280d2dd5db502126d0e7f27"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9dc1b507c12eb0481d071f3c1808f0529ad41dc415d0ca11f7ebfc666e66a18b"},
-    {file = "pydantic_core-2.20.1-cp311-none-win32.whl", hash = "sha256:fa2fddcb7107e0d1808086ca306dcade7df60a13a6c347a7acf1ec139aa6789a"},
-    {file = "pydantic_core-2.20.1-cp311-none-win_amd64.whl", hash = "sha256:40a783fb7ee353c50bd3853e626f15677ea527ae556429453685ae32280c19c2"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:595ba5be69b35777474fa07f80fc260ea71255656191adb22a8c53aba4479231"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a4f55095ad087474999ee28d3398bae183a66be4823f753cd7d67dd0153427c9"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9aa05d09ecf4c75157197f27cdc9cfaeb7c5f15021c6373932bf3e124af029f"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e97fdf088d4b31ff4ba35db26d9cc472ac7ef4a2ff2badeabf8d727b3377fc52"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bc633a9fe1eb87e250b5c57d389cf28998e4292336926b0b6cdaee353f89a237"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d573faf8eb7e6b1cbbcb4f5b247c60ca8be39fe2c674495df0eb4318303137fe"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26dc97754b57d2fd00ac2b24dfa341abffc380b823211994c4efac7f13b9e90e"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:33499e85e739a4b60c9dac710c20a08dc73cb3240c9a0e22325e671b27b70d24"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bebb4d6715c814597f85297c332297c6ce81e29436125ca59d1159b07f423eb1"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:516d9227919612425c8ef1c9b869bbbee249bc91912c8aaffb66116c0b447ebd"},
-    {file = "pydantic_core-2.20.1-cp312-none-win32.whl", hash = "sha256:469f29f9093c9d834432034d33f5fe45699e664f12a13bf38c04967ce233d688"},
-    {file = "pydantic_core-2.20.1-cp312-none-win_amd64.whl", hash = "sha256:035ede2e16da7281041f0e626459bcae33ed998cca6a0a007a5ebb73414ac72d"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:0827505a5c87e8aa285dc31e9ec7f4a17c81a813d45f70b1d9164e03a813a686"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19c0fa39fa154e7e0b7f82f88ef85faa2a4c23cc65aae2f5aea625e3c13c735a"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa223cd1e36b642092c326d694d8bf59b71ddddc94cdb752bbbb1c5c91d833b"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c336a6d235522a62fef872c6295a42ecb0c4e1d0f1a3e500fe949415761b8a19"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7eb6a0587eded33aeefea9f916899d42b1799b7b14b8f8ff2753c0ac1741edac"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:70c8daf4faca8da5a6d655f9af86faf6ec2e1768f4b8b9d0226c02f3d6209703"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9fa4c9bf273ca41f940bceb86922a7667cd5bf90e95dbb157cbb8441008482c"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:11b71d67b4725e7e2a9f6e9c0ac1239bbc0c48cce3dc59f98635efc57d6dac83"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:270755f15174fb983890c49881e93f8f1b80f0b5e3a3cc1394a255706cabd203"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:c81131869240e3e568916ef4c307f8b99583efaa60a8112ef27a366eefba8ef0"},
-    {file = "pydantic_core-2.20.1-cp313-none-win32.whl", hash = "sha256:b91ced227c41aa29c672814f50dbb05ec93536abf8f43cd14ec9521ea09afe4e"},
-    {file = "pydantic_core-2.20.1-cp313-none-win_amd64.whl", hash = "sha256:65db0f2eefcaad1a3950f498aabb4875c8890438bc80b19362cf633b87a8ab20"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:4745f4ac52cc6686390c40eaa01d48b18997cb130833154801a442323cc78f91"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a8ad4c766d3f33ba8fd692f9aa297c9058970530a32c728a2c4bfd2616d3358b"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41e81317dd6a0127cabce83c0c9c3fbecceae981c8391e6f1dec88a77c8a569a"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04024d270cf63f586ad41fff13fde4311c4fc13ea74676962c876d9577bcc78f"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eaad4ff2de1c3823fddf82f41121bdf453d922e9a238642b1dedb33c4e4f98ad"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26ab812fa0c845df815e506be30337e2df27e88399b985d0bb4e3ecfe72df31c"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c5ebac750d9d5f2706654c638c041635c385596caf68f81342011ddfa1e5598"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2aafc5a503855ea5885559eae883978c9b6d8c8993d67766ee73d82e841300dd"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4868f6bd7c9d98904b748a2653031fc9c2f85b6237009d475b1008bfaeb0a5aa"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:aa2f457b4af386254372dfa78a2eda2563680d982422641a85f271c859df1987"},
-    {file = "pydantic_core-2.20.1-cp38-none-win32.whl", hash = "sha256:225b67a1f6d602de0ce7f6c1c3ae89a4aa25d3de9be857999e9124f15dab486a"},
-    {file = "pydantic_core-2.20.1-cp38-none-win_amd64.whl", hash = "sha256:6b507132dcfc0dea440cce23ee2182c0ce7aba7054576efc65634f080dbe9434"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:b03f7941783b4c4a26051846dea594628b38f6940a2fdc0df00b221aed39314c"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1eedfeb6089ed3fad42e81a67755846ad4dcc14d73698c120a82e4ccf0f1f9f6"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:635fee4e041ab9c479e31edda27fcf966ea9614fff1317e280d99eb3e5ab6fe2"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:77bf3ac639c1ff567ae3b47f8d4cc3dc20f9966a2a6dd2311dcc055d3d04fb8a"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ed1b0132f24beeec5a78b67d9388656d03e6a7c837394f99257e2d55b461611"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6514f963b023aeee506678a1cf821fe31159b925c4b76fe2afa94cc70b3222b"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10d4204d8ca33146e761c79f83cc861df20e7ae9f6487ca290a97702daf56006"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2d036c7187b9422ae5b262badb87a20a49eb6c5238b2004e96d4da1231badef1"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9ebfef07dbe1d93efb94b4700f2d278494e9162565a54f124c404a5656d7ff09"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6b9d9bb600328a1ce523ab4f454859e9d439150abb0906c5a1983c146580ebab"},
-    {file = "pydantic_core-2.20.1-cp39-none-win32.whl", hash = "sha256:784c1214cb6dd1e3b15dd8b91b9a53852aed16671cc3fbe4786f4f1db07089e2"},
-    {file = "pydantic_core-2.20.1-cp39-none-win_amd64.whl", hash = "sha256:d2fe69c5434391727efa54b47a1e7986bb0186e72a41b203df8f5b0a19a4f669"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:a45f84b09ac9c3d35dfcf6a27fd0634d30d183205230a0ebe8373a0e8cfa0906"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d02a72df14dfdbaf228424573a07af10637bd490f0901cee872c4f434a735b94"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2b27e6af28f07e2f195552b37d7d66b150adbaa39a6d327766ffd695799780f"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:084659fac3c83fd674596612aeff6041a18402f1e1bc19ca39e417d554468482"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:242b8feb3c493ab78be289c034a1f659e8826e2233786e36f2893a950a719bb6"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:38cf1c40a921d05c5edc61a785c0ddb4bed67827069f535d794ce6bcded919fc"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:e0bbdd76ce9aa5d4209d65f2b27fc6e5ef1312ae6c5333c26db3f5ade53a1e99"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:254ec27fdb5b1ee60684f91683be95e5133c994cc54e86a0b0963afa25c8f8a6"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:407653af5617f0757261ae249d3fba09504d7a71ab36ac057c938572d1bc9331"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:c693e916709c2465b02ca0ad7b387c4f8423d1db7b4649c551f27a529181c5ad"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b5ff4911aea936a47d9376fd3ab17e970cc543d1b68921886e7f64bd28308d1"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:177f55a886d74f1808763976ac4efd29b7ed15c69f4d838bbd74d9d09cf6fa86"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:964faa8a861d2664f0c7ab0c181af0bea66098b1919439815ca8803ef136fc4e"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:4dd484681c15e6b9a977c785a345d3e378d72678fd5f1f3c0509608da24f2ac0"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f6d6cff3538391e8486a431569b77921adfcdef14eb18fbf19b7c0a5294d4e6a"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a6d511cc297ff0883bc3708b465ff82d7560193169a8b93260f74ecb0a5e08a7"},
-    {file = "pydantic_core-2.20.1.tar.gz", hash = "sha256:26ca695eeee5f9f1aeeb211ffc12f10bcb6f71e2989988fda61dabd65db878d4"},
+    {file = "pydantic_core-2.23.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:7f10a5d1b9281392f1bf507d16ac720e78285dfd635b05737c3911637601bae6"},
+    {file = "pydantic_core-2.23.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3c09a7885dd33ee8c65266e5aa7fb7e2f23d49d8043f089989726391dd7350c5"},
+    {file = "pydantic_core-2.23.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6470b5a1ec4d1c2e9afe928c6cb37eb33381cab99292a708b8cb9aa89e62429b"},
+    {file = "pydantic_core-2.23.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9172d2088e27d9a185ea0a6c8cebe227a9139fd90295221d7d495944d2367700"},
+    {file = "pydantic_core-2.23.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:86fc6c762ca7ac8fbbdff80d61b2c59fb6b7d144aa46e2d54d9e1b7b0e780e01"},
+    {file = "pydantic_core-2.23.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f0cb80fd5c2df4898693aa841425ea1727b1b6d2167448253077d2a49003e0ed"},
+    {file = "pydantic_core-2.23.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03667cec5daf43ac4995cefa8aaf58f99de036204a37b889c24a80927b629cec"},
+    {file = "pydantic_core-2.23.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:047531242f8e9c2db733599f1c612925de095e93c9cc0e599e96cf536aaf56ba"},
+    {file = "pydantic_core-2.23.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:5499798317fff7f25dbef9347f4451b91ac2a4330c6669821c8202fd354c7bee"},
+    {file = "pydantic_core-2.23.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:bbb5e45eab7624440516ee3722a3044b83fff4c0372efe183fd6ba678ff681fe"},
+    {file = "pydantic_core-2.23.3-cp310-none-win32.whl", hash = "sha256:8b5b3ed73abb147704a6e9f556d8c5cb078f8c095be4588e669d315e0d11893b"},
+    {file = "pydantic_core-2.23.3-cp310-none-win_amd64.whl", hash = "sha256:2b603cde285322758a0279995b5796d64b63060bfbe214b50a3ca23b5cee3e83"},
+    {file = "pydantic_core-2.23.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:c889fd87e1f1bbeb877c2ee56b63bb297de4636661cc9bbfcf4b34e5e925bc27"},
+    {file = "pydantic_core-2.23.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ea85bda3189fb27503af4c45273735bcde3dd31c1ab17d11f37b04877859ef45"},
+    {file = "pydantic_core-2.23.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a7f7f72f721223f33d3dc98a791666ebc6a91fa023ce63733709f4894a7dc611"},
+    {file = "pydantic_core-2.23.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b2b55b0448e9da68f56b696f313949cda1039e8ec7b5d294285335b53104b61"},
+    {file = "pydantic_core-2.23.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c24574c7e92e2c56379706b9a3f07c1e0c7f2f87a41b6ee86653100c4ce343e5"},
+    {file = "pydantic_core-2.23.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f2b05e6ccbee333a8f4b8f4d7c244fdb7a979e90977ad9c51ea31261e2085ce0"},
+    {file = "pydantic_core-2.23.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2c409ce1c219c091e47cb03feb3c4ed8c2b8e004efc940da0166aaee8f9d6c8"},
+    {file = "pydantic_core-2.23.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d965e8b325f443ed3196db890d85dfebbb09f7384486a77461347f4adb1fa7f8"},
+    {file = "pydantic_core-2.23.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:f56af3a420fb1ffaf43ece3ea09c2d27c444e7c40dcb7c6e7cf57aae764f2b48"},
+    {file = "pydantic_core-2.23.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5b01a078dd4f9a52494370af21aa52964e0a96d4862ac64ff7cea06e0f12d2c5"},
+    {file = "pydantic_core-2.23.3-cp311-none-win32.whl", hash = "sha256:560e32f0df04ac69b3dd818f71339983f6d1f70eb99d4d1f8e9705fb6c34a5c1"},
+    {file = "pydantic_core-2.23.3-cp311-none-win_amd64.whl", hash = "sha256:c744fa100fdea0d000d8bcddee95213d2de2e95b9c12be083370b2072333a0fa"},
+    {file = "pydantic_core-2.23.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:e0ec50663feedf64d21bad0809f5857bac1ce91deded203efc4a84b31b2e4305"},
+    {file = "pydantic_core-2.23.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:db6e6afcb95edbe6b357786684b71008499836e91f2a4a1e55b840955b341dbb"},
+    {file = "pydantic_core-2.23.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:98ccd69edcf49f0875d86942f4418a4e83eb3047f20eb897bffa62a5d419c8fa"},
+    {file = "pydantic_core-2.23.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a678c1ac5c5ec5685af0133262103defb427114e62eafeda12f1357a12140162"},
+    {file = "pydantic_core-2.23.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:01491d8b4d8db9f3391d93b0df60701e644ff0894352947f31fff3e52bd5c801"},
+    {file = "pydantic_core-2.23.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fcf31facf2796a2d3b7fe338fe8640aa0166e4e55b4cb108dbfd1058049bf4cb"},
+    {file = "pydantic_core-2.23.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7200fd561fb3be06827340da066df4311d0b6b8eb0c2116a110be5245dceb326"},
+    {file = "pydantic_core-2.23.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dc1636770a809dee2bd44dd74b89cc80eb41172bcad8af75dd0bc182c2666d4c"},
+    {file = "pydantic_core-2.23.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:67a5def279309f2e23014b608c4150b0c2d323bd7bccd27ff07b001c12c2415c"},
+    {file = "pydantic_core-2.23.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:748bdf985014c6dd3e1e4cc3db90f1c3ecc7246ff5a3cd4ddab20c768b2f1dab"},
+    {file = "pydantic_core-2.23.3-cp312-none-win32.whl", hash = "sha256:255ec6dcb899c115f1e2a64bc9ebc24cc0e3ab097775755244f77360d1f3c06c"},
+    {file = "pydantic_core-2.23.3-cp312-none-win_amd64.whl", hash = "sha256:40b8441be16c1e940abebed83cd006ddb9e3737a279e339dbd6d31578b802f7b"},
+    {file = "pydantic_core-2.23.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:6daaf5b1ba1369a22c8b050b643250e3e5efc6a78366d323294aee54953a4d5f"},
+    {file = "pydantic_core-2.23.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d015e63b985a78a3d4ccffd3bdf22b7c20b3bbd4b8227809b3e8e75bc37f9cb2"},
+    {file = "pydantic_core-2.23.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3fc572d9b5b5cfe13f8e8a6e26271d5d13f80173724b738557a8c7f3a8a3791"},
+    {file = "pydantic_core-2.23.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f6bd91345b5163ee7448bee201ed7dd601ca24f43f439109b0212e296eb5b423"},
+    {file = "pydantic_core-2.23.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc379c73fd66606628b866f661e8785088afe2adaba78e6bbe80796baf708a63"},
+    {file = "pydantic_core-2.23.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fbdce4b47592f9e296e19ac31667daed8753c8367ebb34b9a9bd89dacaa299c9"},
+    {file = "pydantic_core-2.23.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc3cf31edf405a161a0adad83246568647c54404739b614b1ff43dad2b02e6d5"},
+    {file = "pydantic_core-2.23.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e22b477bf90db71c156f89a55bfe4d25177b81fce4aa09294d9e805eec13855"},
+    {file = "pydantic_core-2.23.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:0a0137ddf462575d9bce863c4c95bac3493ba8e22f8c28ca94634b4a1d3e2bb4"},
+    {file = "pydantic_core-2.23.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:203171e48946c3164fe7691fc349c79241ff8f28306abd4cad5f4f75ed80bc8d"},
+    {file = "pydantic_core-2.23.3-cp313-none-win32.whl", hash = "sha256:76bdab0de4acb3f119c2a4bff740e0c7dc2e6de7692774620f7452ce11ca76c8"},
+    {file = "pydantic_core-2.23.3-cp313-none-win_amd64.whl", hash = "sha256:37ba321ac2a46100c578a92e9a6aa33afe9ec99ffa084424291d84e456f490c1"},
+    {file = "pydantic_core-2.23.3-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:d063c6b9fed7d992bcbebfc9133f4c24b7a7f215d6b102f3e082b1117cddb72c"},
+    {file = "pydantic_core-2.23.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6cb968da9a0746a0cf521b2b5ef25fc5a0bee9b9a1a8214e0a1cfaea5be7e8a4"},
+    {file = "pydantic_core-2.23.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edbefe079a520c5984e30e1f1f29325054b59534729c25b874a16a5048028d16"},
+    {file = "pydantic_core-2.23.3-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cbaaf2ef20d282659093913da9d402108203f7cb5955020bd8d1ae5a2325d1c4"},
+    {file = "pydantic_core-2.23.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fb539d7e5dc4aac345846f290cf504d2fd3c1be26ac4e8b5e4c2b688069ff4cf"},
+    {file = "pydantic_core-2.23.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7e6f33503c5495059148cc486867e1d24ca35df5fc064686e631e314d959ad5b"},
+    {file = "pydantic_core-2.23.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:04b07490bc2f6f2717b10c3969e1b830f5720b632f8ae2f3b8b1542394c47a8e"},
+    {file = "pydantic_core-2.23.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:03795b9e8a5d7fda05f3873efc3f59105e2dcff14231680296b87b80bb327295"},
+    {file = "pydantic_core-2.23.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:c483dab0f14b8d3f0df0c6c18d70b21b086f74c87ab03c59250dbf6d3c89baba"},
+    {file = "pydantic_core-2.23.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8b2682038e255e94baf2c473dca914a7460069171ff5cdd4080be18ab8a7fd6e"},
+    {file = "pydantic_core-2.23.3-cp38-none-win32.whl", hash = "sha256:f4a57db8966b3a1d1a350012839c6a0099f0898c56512dfade8a1fe5fb278710"},
+    {file = "pydantic_core-2.23.3-cp38-none-win_amd64.whl", hash = "sha256:13dd45ba2561603681a2676ca56006d6dee94493f03d5cadc055d2055615c3ea"},
+    {file = "pydantic_core-2.23.3-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:82da2f4703894134a9f000e24965df73cc103e31e8c31906cc1ee89fde72cbd8"},
+    {file = "pydantic_core-2.23.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:dd9be0a42de08f4b58a3cc73a123f124f65c24698b95a54c1543065baca8cf0e"},
+    {file = "pydantic_core-2.23.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89b731f25c80830c76fdb13705c68fef6a2b6dc494402987c7ea9584fe189f5d"},
+    {file = "pydantic_core-2.23.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6de1ec30c4bb94f3a69c9f5f2182baeda5b809f806676675e9ef6b8dc936f28"},
+    {file = "pydantic_core-2.23.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bb68b41c3fa64587412b104294b9cbb027509dc2f6958446c502638d481525ef"},
+    {file = "pydantic_core-2.23.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c3980f2843de5184656aab58698011b42763ccba11c4a8c35936c8dd6c7068c"},
+    {file = "pydantic_core-2.23.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94f85614f2cba13f62c3c6481716e4adeae48e1eaa7e8bac379b9d177d93947a"},
+    {file = "pydantic_core-2.23.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:510b7fb0a86dc8f10a8bb43bd2f97beb63cffad1203071dc434dac26453955cd"},
+    {file = "pydantic_core-2.23.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1eba2f7ce3e30ee2170410e2171867ea73dbd692433b81a93758ab2de6c64835"},
+    {file = "pydantic_core-2.23.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4b259fd8409ab84b4041b7b3f24dcc41e4696f180b775961ca8142b5b21d0e70"},
+    {file = "pydantic_core-2.23.3-cp39-none-win32.whl", hash = "sha256:40d9bd259538dba2f40963286009bf7caf18b5112b19d2b55b09c14dde6db6a7"},
+    {file = "pydantic_core-2.23.3-cp39-none-win_amd64.whl", hash = "sha256:5a8cd3074a98ee70173a8633ad3c10e00dcb991ecec57263aacb4095c5efb958"},
+    {file = "pydantic_core-2.23.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:f399e8657c67313476a121a6944311fab377085ca7f490648c9af97fc732732d"},
+    {file = "pydantic_core-2.23.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:6b5547d098c76e1694ba85f05b595720d7c60d342f24d5aad32c3049131fa5c4"},
+    {file = "pydantic_core-2.23.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0dda0290a6f608504882d9f7650975b4651ff91c85673341789a476b1159f211"},
+    {file = "pydantic_core-2.23.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65b6e5da855e9c55a0c67f4db8a492bf13d8d3316a59999cfbaf98cc6e401961"},
+    {file = "pydantic_core-2.23.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:09e926397f392059ce0afdcac920df29d9c833256354d0c55f1584b0b70cf07e"},
+    {file = "pydantic_core-2.23.3-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:87cfa0ed6b8c5bd6ae8b66de941cece179281239d482f363814d2b986b79cedc"},
+    {file = "pydantic_core-2.23.3-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:e61328920154b6a44d98cabcb709f10e8b74276bc709c9a513a8c37a18786cc4"},
+    {file = "pydantic_core-2.23.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:ce3317d155628301d649fe5e16a99528d5680af4ec7aa70b90b8dacd2d725c9b"},
+    {file = "pydantic_core-2.23.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e89513f014c6be0d17b00a9a7c81b1c426f4eb9224b15433f3d98c1a071f8433"},
+    {file = "pydantic_core-2.23.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:4f62c1c953d7ee375df5eb2e44ad50ce2f5aff931723b398b8bc6f0ac159791a"},
+    {file = "pydantic_core-2.23.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2718443bc671c7ac331de4eef9b673063b10af32a0bb385019ad61dcf2cc8f6c"},
+    {file = "pydantic_core-2.23.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0d90e08b2727c5d01af1b5ef4121d2f0c99fbee692c762f4d9d0409c9da6541"},
+    {file = "pydantic_core-2.23.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2b676583fc459c64146debea14ba3af54e540b61762dfc0613dc4e98c3f66eeb"},
+    {file = "pydantic_core-2.23.3-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:50e4661f3337977740fdbfbae084ae5693e505ca2b3130a6d4eb0f2281dc43b8"},
+    {file = "pydantic_core-2.23.3-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:68f4cf373f0de6abfe599a38307f4417c1c867ca381c03df27c873a9069cda25"},
+    {file = "pydantic_core-2.23.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:59d52cf01854cb26c46958552a21acb10dd78a52aa34c86f284e66b209db8cab"},
+    {file = "pydantic_core-2.23.3.tar.gz", hash = "sha256:3cb0f65d8b4121c1b015c60104a685feb929a29d7cf204387c7f2688c7974690"},
 ]
 
 [package.dependencies]
@@ -470,13 +471,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pydantic-xml"
-version = "2.11.0"
+version = "2.12.1"
 description = "pydantic xml extension"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic_xml-2.11.0-py3-none-any.whl", hash = "sha256:033b2b997a99bdb18ab93d7ed66a5bc9ec490753afc011f084bd625ad2d0bdfd"},
-    {file = "pydantic_xml-2.11.0.tar.gz", hash = "sha256:7fbe816b8251b45aabe0c11992fc52e2921afd8f46f256b3f60ed82f869361da"},
+    {file = "pydantic_xml-2.12.1-py3-none-any.whl", hash = "sha256:5de8394dde00d00a899b85fd8e0b915e6f144a068675d8efcbaa225fdcce3880"},
+    {file = "pydantic_xml-2.12.1.tar.gz", hash = "sha256:31623e9b287ef9eb1dda4caa92e893e3ac977f0327e1d76fd8a36879e455cea1"},
 ]
 
 [package.dependencies]
@@ -489,13 +490,13 @@ lxml = ["lxml (>=4.9.0)"]
 
 [[package]]
 name = "pytest"
-version = "8.3.2"
+version = "8.3.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.3.2-py3-none-any.whl", hash = "sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5"},
-    {file = "pytest-8.3.2.tar.gz", hash = "sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce"},
+    {file = "pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2"},
+    {file = "pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -29,7 +29,7 @@ pydantic-xml = "^2.11.0"
 type = "git"
 url = "https://github.com/asam-ev/qc-baselib-py.git"
 reference = "develop"
-resolved_reference = "7c1825ea7bc6ef47b66af91542ccc887cccbeeb8"
+resolved_reference = "f7ea664805bcce456ebd0ede93c852dd389c1944"
 
 [[package]]
 name = "black"

--- a/qc_openscenario/checks/basic_checker/__init__.py
+++ b/qc_openscenario/checks/basic_checker/__init__.py
@@ -1,4 +1,3 @@
-from . import basic_constants as basic_constants
 from . import basic_checker as basic_checker
 from . import valid_xml_document as valid_xml_document
 from . import root_tag_is_openscenario as root_tag_is_openscenario

--- a/qc_openscenario/checks/basic_checker/basic_checker.py
+++ b/qc_openscenario/checks/basic_checker/basic_checker.py
@@ -9,7 +9,6 @@ from qc_openscenario import constants
 from qc_openscenario.checks import utils, models
 
 from qc_openscenario.checks.basic_checker import (
-    basic_constants,
     valid_xml_document,
     root_tag_is_openscenario,
     fileheader_is_present,
@@ -20,47 +19,28 @@ from qc_openscenario.checks.basic_checker import (
 def run_checks(config: Configuration, result: Result) -> models.CheckerData:
     logging.info("Executing basic checks")
 
-    result.register_checker(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=basic_constants.CHECKER_ID,
-        description="Check if basic properties of input file are properly set",
-        summary="",
-    )
-
     xml_file_path = config.get_config_param("InputFile")
 
-    is_xml = valid_xml_document.check_rule(xml_file_path, result)
+    valid_xml_document.check_rule(xml_file_path, result)
+
     root = None
-    checker_data = None
-
-    basic_rule_list = [
-        root_tag_is_openscenario.check_rule,
-        fileheader_is_present.check_rule,
-        version_is_defined.check_rule,
-    ]
-
-    validation_result = is_xml
-    if validation_result:
+    if result.all_checkers_completed_without_issue({valid_xml_document.CHECKER_ID}):
         root = utils.get_root_without_default_namespace(xml_file_path)
 
-        for rule in basic_rule_list:
-            validation_result = validation_result and rule(root, result)
-            if not validation_result:
-                break
+    root_tag_is_openscenario.check_rule(root, result)
+    fileheader_is_present.check_rule(root, result)
+    version_is_defined.check_rule(root, result)
 
-    if not validation_result:
-        logging.warning(
-            "There are problems with input file. Error found in basic rules!"
-        )
-        checker_data = models.CheckerData(
-            input_file_xml_root=None,
-            config=config,
-            result=result,
-            schema_version=None,
-            xodr_root=None,
-        )
+    checker_data = None
 
-    else:
+    if result.all_checkers_completed_without_issue(
+        {
+            valid_xml_document.CHECKER_ID,
+            root_tag_is_openscenario.CHECKER_ID,
+            fileheader_is_present.CHECKER_ID,
+            version_is_defined.CHECKER_ID,
+        }
+    ):
         xosc_schema_version = utils.get_standard_schema_version(root)
         xodr_root = utils.get_xodr_road_network(xml_file_path, root)
         checker_data = models.CheckerData(
@@ -70,16 +50,14 @@ def run_checks(config: Configuration, result: Result) -> models.CheckerData:
             schema_version=xosc_schema_version,
             xodr_root=xodr_root,
         )
-
-    logging.info(
-        f"Issues found - {result.get_checker_issue_count(checker_bundle_name=constants.BUNDLE_NAME, checker_id=basic_constants.CHECKER_ID)}"
-    )
-
-    # TODO: Add logic to deal with error or to skip it
-    result.set_checker_status(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=basic_constants.CHECKER_ID,
-        status=StatusType.COMPLETED,
-    )
+    else:
+        logging.info("Error found in basic rules!")
+        checker_data = models.CheckerData(
+            input_file_xml_root=None,
+            config=config,
+            result=result,
+            schema_version=None,
+            xodr_root=None,
+        )
 
     return checker_data

--- a/qc_openscenario/checks/basic_checker/basic_constants.py
+++ b/qc_openscenario/checks/basic_checker/basic_constants.py
@@ -1,1 +1,0 @@
-CHECKER_ID = "basic_xosc"

--- a/qc_openscenario/checks/basic_checker/fileheader_is_present.py
+++ b/qc_openscenario/checks/basic_checker/fileheader_is_present.py
@@ -1,30 +1,50 @@
 import logging
 from lxml import etree
-from qc_baselib import IssueSeverity, Result
+from qc_baselib import IssueSeverity, Result, StatusType
 
 from qc_openscenario import constants
-from qc_openscenario.checks import models
 
-from qc_openscenario.checks.basic_checker import basic_constants
+from qc_openscenario.checks.basic_checker import (
+    valid_xml_document,
+    root_tag_is_openscenario,
+)
+
+CHECKER_ID = "check_asam_xosc_xml_fileheader_is_present"
+PRECONDITIONS = {valid_xml_document.CHECKER_ID, root_tag_is_openscenario.CHECKER_ID}
 
 
-def check_rule(tree: etree._ElementTree, result: Result) -> bool:
+def check_rule(tree: etree._ElementTree, result: Result) -> None:
     """
-    Below the root element a tag with FileHeader must be defined
+    Below the root element a tag with FileHeader must be defined.
 
     More info at
         - https://github.com/asam-ev/qc-openscenarioxml/issues/41
     """
     logging.info("Executing fileheader_is_present check")
 
+    result.register_checker(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        description="Below the root element a tag with FileHeader must be defined.",
+    )
+
     rule_uid = result.register_rule(
         checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=basic_constants.CHECKER_ID,
+        checker_id=CHECKER_ID,
         emanating_entity="asam.net",
         standard="xosc",
         definition_setting="1.0.0",
         rule_full_name="xml.fileheader_is_present",
     )
+
+    if not result.all_checkers_completed_without_issue(PRECONDITIONS):
+        result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
+
+        return
 
     root = tree.getroot()
 
@@ -42,7 +62,7 @@ def check_rule(tree: etree._ElementTree, result: Result) -> bool:
 
         issue_id = result.register_issue(
             checker_bundle_name=constants.BUNDLE_NAME,
-            checker_id=basic_constants.CHECKER_ID,
+            checker_id=CHECKER_ID,
             description="Issue flagging when no FileHeader is found under root element",
             level=IssueSeverity.ERROR,
             rule_uid=rule_uid,
@@ -50,12 +70,14 @@ def check_rule(tree: etree._ElementTree, result: Result) -> bool:
 
         result.add_xml_location(
             checker_bundle_name=constants.BUNDLE_NAME,
-            checker_id=basic_constants.CHECKER_ID,
+            checker_id=CHECKER_ID,
             issue_id=issue_id,
             xpath=tree.getpath(root),
             description=f'No child element "FileHeader"',
         )
 
-        return False
-
-    return True
+    result.set_checker_status(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        status=StatusType.COMPLETED,
+    )

--- a/qc_openscenario/checks/basic_checker/valid_xml_document.py
+++ b/qc_openscenario/checks/basic_checker/valid_xml_document.py
@@ -1,16 +1,11 @@
 import logging
 
-from dataclasses import dataclass
-from typing import List
-
 from lxml import etree
 
-from qc_baselib import Configuration, Result, IssueSeverity
-
+from qc_baselib import Result, IssueSeverity, StatusType
 from qc_openscenario import constants
-from qc_openscenario.checks import utils, models
 
-from qc_openscenario.checks.basic_checker import basic_constants
+CHECKER_ID = "check_asam_xosc_xml_valid_xml_document"
 
 
 def _is_xml_doc(file_path: str) -> tuple[bool, tuple[int, int]]:
@@ -26,7 +21,7 @@ def _is_xml_doc(file_path: str) -> tuple[bool, tuple[int, int]]:
         return False, (e.lineno, e.offset)
 
 
-def check_rule(input_xml_file_path: str, result: Result) -> bool:
+def check_rule(input_xml_file_path: str, result: Result) -> None:
     """
     Implements a rule to check if input file is a valid xml document
 
@@ -35,9 +30,15 @@ def check_rule(input_xml_file_path: str, result: Result) -> bool:
     """
     logging.info("Executing valid_xml_document check")
 
+    result.register_checker(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        description="The given file to check must be a valid XML document.",
+    )
+
     rule_uid = result.register_rule(
         checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=basic_constants.CHECKER_ID,
+        checker_id=CHECKER_ID,
         emanating_entity="asam.net",
         standard="xosc",
         definition_setting="1.0.0",
@@ -50,21 +51,23 @@ def check_rule(input_xml_file_path: str, result: Result) -> bool:
 
         issue_id = result.register_issue(
             checker_bundle_name=constants.BUNDLE_NAME,
-            checker_id=basic_constants.CHECKER_ID,
-            description="Issue flagging when input file is not a valid xml document",
+            checker_id=CHECKER_ID,
+            description="The input file is not a valid xml document",
             level=IssueSeverity.ERROR,
             rule_uid=rule_uid,
         )
 
         result.add_file_location(
             checker_bundle_name=constants.BUNDLE_NAME,
-            checker_id=basic_constants.CHECKER_ID,
+            checker_id=CHECKER_ID,
             issue_id=issue_id,
             row=error_location[0],
             column=error_location[1],
-            description=f"Invalid xml detected",
+            description=f"Invalid xml file.",
         )
 
-        return False
-
-    return True
+    result.set_checker_status(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        status=StatusType.COMPLETED,
+    )

--- a/qc_openscenario/checks/data_type_checker/__init__.py
+++ b/qc_openscenario/checks/data_type_checker/__init__.py
@@ -1,4 +1,4 @@
-from . import data_type_constants as data_type_constants
+from . import data_type_checker_precondition as data_type_checker_precondition
 from . import data_type_checker as data_type_checker
 from . import allowed_operators as allowed_operators
 from . import (

--- a/qc_openscenario/checks/data_type_checker/data_type_checker.py
+++ b/qc_openscenario/checks/data_type_checker/data_type_checker.py
@@ -1,15 +1,8 @@
 import logging
 
-from lxml import etree
-
-from qc_baselib import Configuration, Result, StatusType
-
-from qc_openscenario import constants
-from qc_openscenario.checks import utils, models
-from qc_openscenario.schema import schema_files
+from qc_openscenario.checks import models
 
 from qc_openscenario.checks.data_type_checker import (
-    data_type_constants,
     allowed_operators,
     non_negative_transition_time_in_light_state_action,
     positive_duration_in_phase,
@@ -19,52 +12,6 @@ from qc_openscenario.checks.data_type_checker import (
 def run_checks(checker_data: models.CheckerData) -> None:
     logging.info("Executing data_type checks")
 
-    checker_data.result.register_checker(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=data_type_constants.CHECKER_ID,
-        description="Check if data_type properties of input file are properly set",
-        summary="",
-    )
-
-    if checker_data.input_file_xml_root is None:
-        logging.error(
-            f"Invalid xml input file. Checker {data_type_constants.CHECKER_ID} skipped"
-        )
-        checker_data.result.set_checker_status(
-            checker_bundle_name=constants.BUNDLE_NAME,
-            checker_id=data_type_constants.CHECKER_ID,
-            status=StatusType.SKIPPED,
-        )
-        return
-
-    if checker_data.schema_version not in schema_files.SCHEMA_FILES:
-
-        logging.error(
-            f"Version {checker_data.schema_version} unsupported. Checker {data_type_constants.CHECKER_ID} skipped"
-        )
-        checker_data.result.set_checker_status(
-            checker_bundle_name=constants.BUNDLE_NAME,
-            checker_id=data_type_constants.CHECKER_ID,
-            status=StatusType.SKIPPED,
-        )
-        return
-
-    rule_list = [
-        allowed_operators.check_rule,
-        non_negative_transition_time_in_light_state_action.check_rule,
-        positive_duration_in_phase.check_rule,
-    ]
-
-    for rule in rule_list:
-        rule(checker_data=checker_data)
-
-    logging.info(
-        f"Issues found - {checker_data.result.get_checker_issue_count(checker_bundle_name=constants.BUNDLE_NAME, checker_id=data_type_constants.CHECKER_ID)}"
-    )
-
-    # TODO: Add logic to deal with error or to skip it
-    checker_data.result.set_checker_status(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=data_type_constants.CHECKER_ID,
-        status=StatusType.COMPLETED,
-    )
+    allowed_operators.check_rule(checker_data)
+    non_negative_transition_time_in_light_state_action.check_rule(checker_data)
+    positive_duration_in_phase.check_rule(checker_data)

--- a/qc_openscenario/checks/data_type_checker/data_type_checker_precondition.py
+++ b/qc_openscenario/checks/data_type_checker/data_type_checker_precondition.py
@@ -1,0 +1,16 @@
+from qc_openscenario.checks.basic_checker import (
+    valid_xml_document,
+    root_tag_is_openscenario,
+    fileheader_is_present,
+    version_is_defined,
+)
+
+from qc_openscenario.checks.schema_checker import valid_schema
+
+PRECONDITIONS = {
+    valid_xml_document.CHECKER_ID,
+    root_tag_is_openscenario.CHECKER_ID,
+    fileheader_is_present.CHECKER_ID,
+    version_is_defined.CHECKER_ID,
+    valid_schema.CHECKER_ID,
+}

--- a/qc_openscenario/checks/data_type_checker/data_type_constants.py
+++ b/qc_openscenario/checks/data_type_checker/data_type_constants.py
@@ -1,1 +1,0 @@
-CHECKER_ID = "data_type_xosc"

--- a/qc_openscenario/checks/data_type_checker/non_negative_transition_time_in_light_state_action.py
+++ b/qc_openscenario/checks/data_type_checker/non_negative_transition_time_in_light_state_action.py
@@ -1,20 +1,16 @@
-import os, logging
+import logging
 
-from dataclasses import dataclass
-from typing import List
-
-from lxml import etree
-
-from qc_baselib import Configuration, Result, IssueSeverity
+from qc_baselib import IssueSeverity, StatusType
 
 from qc_openscenario import constants
-from qc_openscenario.schema import schema_files
 from qc_openscenario.checks import utils, models
 
-from qc_openscenario.checks.data_type_checker import data_type_constants
+from qc_openscenario.checks.data_type_checker import data_type_checker_precondition
 
+CHECKER_ID = (
+    "check_asam_xosc_data_type_non_negative_transition_time_in_light_state_action"
+)
 MIN_RULE_VERSION = "1.2.0"
-RULE_SEVERITY = IssueSeverity.ERROR
 
 
 def check_rule(checker_data: models.CheckerData) -> None:
@@ -34,25 +30,44 @@ def check_rule(checker_data: models.CheckerData) -> None:
     """
     logging.info("Executing non_negative_transition_time_in_light_state_action check")
 
-    schema_version = checker_data.schema_version
-    if schema_version is None:
-        logging.info(f"- Version not found in the file. Skipping check")
-        return
-
-    if utils.compare_versions(schema_version, MIN_RULE_VERSION) < 0:
-        logging.info(
-            f"- Version {schema_version} is less than minimum required version {MIN_RULE_VERSION}. Skipping check"
-        )
-        return
+    checker_data.result.register_checker(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        description="Expressions in OpenSCENARIO must only use the allowed operands.",
+    )
 
     rule_uid = checker_data.result.register_rule(
         checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=data_type_constants.CHECKER_ID,
+        checker_id=CHECKER_ID,
         emanating_entity="asam.net",
         standard="xosc",
         definition_setting=MIN_RULE_VERSION,
         rule_full_name="data_type.non_negative_transition_time_in_light_state_action",
     )
+
+    if not checker_data.result.all_checkers_completed_without_issue(
+        data_type_checker_precondition.PRECONDITIONS
+    ):
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
+
+        return
+
+    schema_version = checker_data.schema_version
+    if (
+        schema_version is None
+        or utils.compare_versions(schema_version, MIN_RULE_VERSION) < 0
+    ):
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
+
+        return
 
     root = checker_data.input_file_xml_root
 
@@ -98,6 +113,13 @@ def check_rule(checker_data: models.CheckerData) -> None:
             logging.error(
                 f"Cannot convert '{current_transition_time}' to double as it does not match xsd:double pattern. Skipping check..."
             )
+
+            checker_data.result.set_checker_status(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                status=StatusType.SKIPPED,
+            )
+
             return
 
         current_numeric_value = float(current_transition_time)
@@ -108,15 +130,21 @@ def check_rule(checker_data: models.CheckerData) -> None:
 
             issue_id = checker_data.result.register_issue(
                 checker_bundle_name=constants.BUNDLE_NAME,
-                checker_id=data_type_constants.CHECKER_ID,
+                checker_id=CHECKER_ID,
                 description="Issue transitionTime in LightStateAction node is negative",
-                level=RULE_SEVERITY,
+                level=IssueSeverity.ERROR,
                 rule_uid=rule_uid,
             )
             checker_data.result.add_xml_location(
                 checker_bundle_name=constants.BUNDLE_NAME,
-                checker_id=data_type_constants.CHECKER_ID,
+                checker_id=CHECKER_ID,
                 issue_id=issue_id,
                 xpath=xpath,
                 description=f"transitionTime duration {current_numeric_value} is negative",
             )
+
+    checker_data.result.set_checker_status(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        status=StatusType.COMPLETED,
+    )

--- a/qc_openscenario/checks/data_type_checker/positive_duration_in_phase.py
+++ b/qc_openscenario/checks/data_type_checker/positive_duration_in_phase.py
@@ -1,20 +1,14 @@
-import os, logging
+import logging
 
-from dataclasses import dataclass
-from typing import List
-
-from lxml import etree
-
-from qc_baselib import Configuration, Result, IssueSeverity
+from qc_baselib import IssueSeverity, StatusType
 
 from qc_openscenario import constants
-from qc_openscenario.schema import schema_files
 from qc_openscenario.checks import utils, models
 
-from qc_openscenario.checks.data_type_checker import data_type_constants
+from qc_openscenario.checks.data_type_checker import data_type_checker_precondition
 
+CHECKER_ID = "check_asam_xosc_positive_duration_in_phase"
 MIN_RULE_VERSION = "1.2.0"
-RULE_SEVERITY = IssueSeverity.ERROR
 
 
 def check_rule(checker_data: models.CheckerData) -> None:
@@ -34,25 +28,44 @@ def check_rule(checker_data: models.CheckerData) -> None:
     """
     logging.info("Executing positive_duration_in_phase check")
 
-    schema_version = checker_data.schema_version
-    if schema_version is None:
-        logging.info(f"- Version not found in the file. Skipping check")
-        return
-
-    if utils.compare_versions(schema_version, MIN_RULE_VERSION) < 0:
-        logging.info(
-            f"- Version {schema_version} is less than minimum required version {MIN_RULE_VERSION}. Skipping check"
-        )
-        return
+    checker_data.result.register_checker(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        description="Expressions in OpenSCENARIO must only use the allowed operands.",
+    )
 
     rule_uid = checker_data.result.register_rule(
         checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=data_type_constants.CHECKER_ID,
+        checker_id=CHECKER_ID,
         emanating_entity="asam.net",
         standard="xosc",
         definition_setting=MIN_RULE_VERSION,
         rule_full_name="data_type.positive_duration_in_phase",
     )
+
+    if not checker_data.result.all_checkers_completed_without_issue(
+        data_type_checker_precondition.PRECONDITIONS
+    ):
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
+
+        return
+
+    schema_version = checker_data.schema_version
+    if (
+        schema_version is None
+        or utils.compare_versions(schema_version, MIN_RULE_VERSION) < 0
+    ):
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
+
+        return
 
     root = checker_data.input_file_xml_root
 
@@ -89,6 +102,13 @@ def check_rule(checker_data: models.CheckerData) -> None:
             logging.error(
                 f"Cannot convert '{current_duration}' to double as it does not match xsd:double pattern. Skipping check..."
             )
+
+            checker_data.result.set_checker_status(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=CHECKER_ID,
+                status=StatusType.SKIPPED,
+            )
+
             return
 
         current_numeric_value = float(current_duration)
@@ -99,15 +119,21 @@ def check_rule(checker_data: models.CheckerData) -> None:
 
             issue_id = checker_data.result.register_issue(
                 checker_bundle_name=constants.BUNDLE_NAME,
-                checker_id=data_type_constants.CHECKER_ID,
+                checker_id=CHECKER_ID,
                 description="Issue flagging when attribute “duration” in the complex type “Phase” is negative",
-                level=RULE_SEVERITY,
+                level=IssueSeverity.ERROR,
                 rule_uid=rule_uid,
             )
             checker_data.result.add_xml_location(
                 checker_bundle_name=constants.BUNDLE_NAME,
-                checker_id=data_type_constants.CHECKER_ID,
+                checker_id=CHECKER_ID,
                 issue_id=issue_id,
                 xpath=xpath,
                 description=f"Phase duration {current_numeric_value} is negative",
             )
+
+    checker_data.result.set_checker_status(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        status=StatusType.COMPLETED,
+    )

--- a/qc_openscenario/checks/parameters_checker/__init__.py
+++ b/qc_openscenario/checks/parameters_checker/__init__.py
@@ -1,5 +1,5 @@
-from . import parameters_constants as parameters_constants
 from . import parameters_checker as parameters_checker
+from . import parameter_checker_precondition as parameter_checker_precondition
 from . import (
     valid_parameter_declaration_in_catalogs as valid_parameter_declaration_in_catalogs,
 )

--- a/qc_openscenario/checks/parameters_checker/parameter_checker_precondition.py
+++ b/qc_openscenario/checks/parameters_checker/parameter_checker_precondition.py
@@ -1,0 +1,16 @@
+from qc_openscenario.checks.basic_checker import (
+    valid_xml_document,
+    root_tag_is_openscenario,
+    fileheader_is_present,
+    version_is_defined,
+)
+
+from qc_openscenario.checks.schema_checker import valid_schema
+
+PRECONDITIONS = {
+    valid_xml_document.CHECKER_ID,
+    root_tag_is_openscenario.CHECKER_ID,
+    fileheader_is_present.CHECKER_ID,
+    version_is_defined.CHECKER_ID,
+    valid_schema.CHECKER_ID,
+}

--- a/qc_openscenario/checks/parameters_checker/parameters_checker.py
+++ b/qc_openscenario/checks/parameters_checker/parameters_checker.py
@@ -1,64 +1,10 @@
 import logging
-
-from lxml import etree
-
-from qc_baselib import Configuration, Result, StatusType
-
-from qc_openscenario import constants
-from qc_openscenario.checks import utils, models
-from qc_openscenario.schema import schema_files
-
+from qc_openscenario.checks import models
 from qc_openscenario.checks.parameters_checker import (
-    parameters_constants,
     valid_parameter_declaration_in_catalogs,
 )
 
 
 def run_checks(checker_data: models.CheckerData) -> None:
     logging.info("Executing parameters checks")
-
-    checker_data.result.register_checker(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=parameters_constants.CHECKER_ID,
-        description="Check if parameters properties of input file are properly set",
-        summary="",
-    )
-
-    if checker_data.input_file_xml_root is None:
-        logging.error(
-            f"Invalid xml input file. Checker {parameters_constants.CHECKER_ID} skipped"
-        )
-        checker_data.result.set_checker_status(
-            checker_bundle_name=constants.BUNDLE_NAME,
-            checker_id=parameters_constants.CHECKER_ID,
-            status=StatusType.SKIPPED,
-        )
-        return
-
-    if checker_data.schema_version not in schema_files.SCHEMA_FILES:
-
-        logging.error(
-            f"Version {checker_data.schema_version} unsupported. Checker {parameters_constants.CHECKER_ID} skipped"
-        )
-        checker_data.result.set_checker_status(
-            checker_bundle_name=constants.BUNDLE_NAME,
-            checker_id=parameters_constants.CHECKER_ID,
-            status=StatusType.SKIPPED,
-        )
-        return
-
-    rule_list = [valid_parameter_declaration_in_catalogs.check_rule]
-
-    for rule in rule_list:
-        rule(checker_data=checker_data)
-
-    logging.info(
-        f"Issues found - {checker_data.result.get_checker_issue_count(checker_bundle_name=constants.BUNDLE_NAME, checker_id=parameters_constants.CHECKER_ID)}"
-    )
-
-    # TODO: Add logic to deal with error or to skip it
-    checker_data.result.set_checker_status(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=parameters_constants.CHECKER_ID,
-        status=StatusType.COMPLETED,
-    )
+    valid_parameter_declaration_in_catalogs.check_rule(checker_data)

--- a/qc_openscenario/checks/parameters_checker/parameters_constants.py
+++ b/qc_openscenario/checks/parameters_checker/parameters_constants.py
@@ -1,1 +1,0 @@
-CHECKER_ID = "parameters_xosc"

--- a/qc_openscenario/checks/reference_checker/__init__.py
+++ b/qc_openscenario/checks/reference_checker/__init__.py
@@ -1,4 +1,3 @@
-from . import reference_constants as reference_constants
 from . import reference_checker as reference_checker
 from . import (
     uniquely_resolvable_entity_references as uniquely_resolvable_entity_references,
@@ -18,3 +17,4 @@ from . import (
     resolvable_storyboard_element_reference as resolvable_storyboard_element_reference,
 )
 from . import unique_element_names_on_same_level as unique_element_names_on_same_level
+from . import reference_checker_precondition as reference_checker_precondition

--- a/qc_openscenario/checks/reference_checker/reference_checker.py
+++ b/qc_openscenario/checks/reference_checker/reference_checker.py
@@ -1,14 +1,14 @@
 import logging
 
-from lxml import etree
 
-from qc_baselib import Configuration, Result, StatusType
+from qc_baselib import StatusType
 
 from qc_openscenario import constants
-from qc_openscenario.checks import utils, models
+from qc_openscenario.checks import models
+
+from qc_openscenario.checks.schema_checker import valid_schema
 
 from qc_openscenario.checks.reference_checker import (
-    reference_constants,
     uniquely_resolvable_entity_references,
     resolvable_signal_id_in_traffic_signal_state_action,
     resolvable_traffic_signal_controller_by_traffic_signal_controller_ref,
@@ -23,61 +23,15 @@ from qc_openscenario.checks.reference_checker import (
 def run_checks(checker_data: models.CheckerData) -> None:
     logging.info("Executing reference checks")
 
-    checker_data.result.register_checker(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-        description="Check if xml properties of input file are properly set",
-        summary="",
+    uniquely_resolvable_entity_references.check_rule(checker_data=checker_data)
+    resolvable_signal_id_in_traffic_signal_state_action.check_rule(
+        checker_data=checker_data
     )
-
-    # Skip if basic checks fail
-    if checker_data.input_file_xml_root is None:
-        logging.error(
-            f"Invalid xml input file. Checker {reference_constants.CHECKER_ID} skipped"
-        )
-        checker_data.result.set_checker_status(
-            checker_bundle_name=constants.BUNDLE_NAME,
-            checker_id=reference_constants.CHECKER_ID,
-            status=StatusType.SKIPPED,
-        )
-        return
-
-    # Skip if schema checks are skipped
-    if (
-        checker_data.result.get_checker_result("xoscBundle", "schema_xosc").status
-        is StatusType.SKIPPED
-    ):
-        logging.error(
-            f"Schema checks have been skipped. Checker {reference_constants.CHECKER_ID} skipped"
-        )
-        checker_data.result.set_checker_status(
-            checker_bundle_name=constants.BUNDLE_NAME,
-            checker_id=reference_constants.CHECKER_ID,
-            status=StatusType.SKIPPED,
-        )
-        return
-
-    rule_list = [
-        uniquely_resolvable_entity_references.check_rule,
-        resolvable_signal_id_in_traffic_signal_state_action.check_rule,
-        resolvable_traffic_signal_controller_by_traffic_signal_controller_ref.check_rule,
-        valid_actor_reference_in_private_actions.check_rule,
-        resolvable_entity_references.check_rule,
-        resolvable_variable_reference.check_rule,
-        resolvable_storyboard_element_reference.check_rule,
-        unique_element_names_on_same_level.check_rule,
-    ]
-
-    for rule in rule_list:
-        rule(checker_data=checker_data)
-
-    logging.info(
-        f"Issues found - {checker_data.result.get_checker_issue_count(checker_bundle_name=constants.BUNDLE_NAME, checker_id=reference_constants.CHECKER_ID)}"
+    resolvable_traffic_signal_controller_by_traffic_signal_controller_ref.check_rule(
+        checker_data=checker_data
     )
-
-    # TODO: Add logic to deal with error or to skip it
-    checker_data.result.set_checker_status(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-        status=StatusType.COMPLETED,
-    )
+    valid_actor_reference_in_private_actions.check_rule(checker_data=checker_data)
+    resolvable_entity_references.check_rule(checker_data=checker_data)
+    resolvable_variable_reference.check_rule(checker_data=checker_data)
+    resolvable_storyboard_element_reference.check_rule(checker_data=checker_data)
+    unique_element_names_on_same_level.check_rule(checker_data=checker_data)

--- a/qc_openscenario/checks/reference_checker/reference_checker_precondition.py
+++ b/qc_openscenario/checks/reference_checker/reference_checker_precondition.py
@@ -1,0 +1,16 @@
+from qc_openscenario.checks.basic_checker import (
+    valid_xml_document,
+    root_tag_is_openscenario,
+    fileheader_is_present,
+    version_is_defined,
+)
+
+from qc_openscenario.checks.schema_checker import valid_schema
+
+PRECONDITIONS = {
+    valid_xml_document.CHECKER_ID,
+    root_tag_is_openscenario.CHECKER_ID,
+    fileheader_is_present.CHECKER_ID,
+    version_is_defined.CHECKER_ID,
+    valid_schema.CHECKER_ID,
+}

--- a/qc_openscenario/checks/reference_checker/reference_constants.py
+++ b/qc_openscenario/checks/reference_checker/reference_constants.py
@@ -1,1 +1,0 @@
-CHECKER_ID = "reference_xosc"

--- a/qc_openscenario/checks/reference_checker/resolvable_signal_id_in_traffic_signal_state_action.py
+++ b/qc_openscenario/checks/reference_checker/resolvable_signal_id_in_traffic_signal_state_action.py
@@ -1,21 +1,13 @@
-import os, logging
+import logging
 
-from dataclasses import dataclass
-from typing import List
-
-from lxml import etree
-
-from qc_baselib import Configuration, Result, IssueSeverity
+from qc_baselib import IssueSeverity, StatusType
 
 from qc_openscenario import constants
-from qc_openscenario.schema import schema_files
 from qc_openscenario.checks import utils, models
+from qc_openscenario.checks.reference_checker import reference_checker_precondition
 
-from qc_openscenario.checks.reference_checker import reference_constants
-from collections import deque, defaultdict
-
+CHECKER_ID = "check_asam_xosc_reference_control_resolvable_signal_id_in_traffic_signal_state_action"
 MIN_RULE_VERSION = "1.2.0"
-RULE_SEVERITY = IssueSeverity.ERROR
 
 
 def check_rule(checker_data: models.CheckerData) -> None:
@@ -35,36 +27,65 @@ def check_rule(checker_data: models.CheckerData) -> None:
     """
     logging.info("Executing resolvable_signal_id_in_traffic_signal_state_action check")
 
-    schema_version = checker_data.schema_version
-    if schema_version is None:
-        logging.info(f"- Version not found in the file. Skipping check")
-        return
-
-    if utils.compare_versions(schema_version, MIN_RULE_VERSION) < 0:
-        logging.info(
-            f"- Version {schema_version} is less than minimum required version {MIN_RULE_VERSION}. Skipping check"
-        )
-        return
+    checker_data.result.register_checker(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        description="TrafficSignalStateAction:name -> Signal ID must exist within the given road network.",
+    )
 
     rule_uid = checker_data.result.register_rule(
         checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
+        checker_id=CHECKER_ID,
         emanating_entity="asam.net",
         standard="xosc",
         definition_setting=MIN_RULE_VERSION,
         rule_full_name="reference_control.resolvable_signal_id_in_traffic_signal_state_action",
     )
 
+    if not checker_data.result.all_checkers_completed_without_issue(
+        reference_checker_precondition.PRECONDITIONS
+    ):
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
+
+        return
+
+    schema_version = checker_data.schema_version
+    if (
+        schema_version is None
+        or utils.compare_versions(schema_version, MIN_RULE_VERSION) < 0
+    ):
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
+
+        return
+
     root = checker_data.input_file_xml_root
 
     if checker_data.xodr_root is None:
         logging.error(f" - Cannot read xodr file. Abort")
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
         return
 
     xodr_signal_list = checker_data.xodr_root.findall(".//signal")
 
     if xodr_signal_list is None:
         logging.error(f" - Cannot read signals from xodr file. Abort")
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
         return
 
     xodr_signal_ids = set()
@@ -82,15 +103,21 @@ def check_rule(checker_data: models.CheckerData) -> None:
             xpath = root.getpath(xosc_traffic_light)
             issue_id = checker_data.result.register_issue(
                 checker_bundle_name=constants.BUNDLE_NAME,
-                checker_id=reference_constants.CHECKER_ID,
+                checker_id=CHECKER_ID,
                 description="Issue flagging traffic light id not present in linked xodr file",
-                level=RULE_SEVERITY,
+                level=IssueSeverity.ERROR,
                 rule_uid=rule_uid,
             )
             checker_data.result.add_xml_location(
                 checker_bundle_name=constants.BUNDLE_NAME,
-                checker_id=reference_constants.CHECKER_ID,
+                checker_id=CHECKER_ID,
                 issue_id=issue_id,
                 xpath=xpath,
                 description=f"Traffic Light {xpath} with id {current_name} not found in xodr file",
             )
+
+    checker_data.result.set_checker_status(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        status=StatusType.COMPLETED,
+    )

--- a/qc_openscenario/checks/reference_checker/resolvable_storyboard_element_reference.py
+++ b/qc_openscenario/checks/reference_checker/resolvable_storyboard_element_reference.py
@@ -1,21 +1,14 @@
-import os, logging
+import logging
 
-from dataclasses import dataclass
-from typing import List
-
-from lxml import etree
-
-from qc_baselib import Configuration, Result, IssueSeverity
+from qc_baselib import IssueSeverity, StatusType
 
 from qc_openscenario import constants
-from qc_openscenario.schema import schema_files
 from qc_openscenario.checks import utils, models
 
-from qc_openscenario.checks.reference_checker import reference_constants
-from collections import deque, defaultdict
+from qc_openscenario.checks.reference_checker import reference_checker_precondition
 
+CHECKER_ID = "check_asam_xosc_reference_control_resolvable_storyboard_element_reference"
 MIN_RULE_VERSION = "1.2.0"
-RULE_SEVERITY = IssueSeverity.ERROR
 STORYBOARD_ELEMENTS = ["Act", "Action", "Event", "Maneuver", "ManeuverGroup", " Story"]
 
 
@@ -37,25 +30,44 @@ def check_rule(checker_data: models.CheckerData) -> None:
     """
     logging.info("Executing resolvable_storyboard_element_reference check")
 
-    schema_version = checker_data.schema_version
-    if schema_version is None:
-        logging.info(f"- Version not found in the file. Skipping check")
-        return
-
-    if utils.compare_versions(schema_version, MIN_RULE_VERSION) < 0:
-        logging.info(
-            f"- Version {schema_version} is less than minimum required version {MIN_RULE_VERSION}. Skipping check"
-        )
-        return
+    checker_data.result.register_checker(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        description="The attribute storyboardElementRef shall point to an existing element of the corresponding type and shall be uniquely resolvable.",
+    )
 
     rule_uid = checker_data.result.register_rule(
         checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
+        checker_id=CHECKER_ID,
         emanating_entity="asam.net",
         standard="xosc",
         definition_setting=MIN_RULE_VERSION,
         rule_full_name="reference_control.resolvable_storyboard_element_reference",
     )
+
+    if not checker_data.result.all_checkers_completed_without_issue(
+        reference_checker_precondition.PRECONDITIONS
+    ):
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
+
+        return
+
+    schema_version = checker_data.schema_version
+    if (
+        schema_version is None
+        or utils.compare_versions(schema_version, MIN_RULE_VERSION) < 0
+    ):
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
+
+        return
 
     root = checker_data.input_file_xml_root
 
@@ -64,6 +76,11 @@ def check_rule(checker_data: models.CheckerData) -> None:
         logging.error(
             "Cannot find Storyboard node in provided XOSC file. Skipping check"
         )
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
         return
 
     xpath_expr = "|".join([f"//{node}" for node in STORYBOARD_ELEMENTS])
@@ -71,6 +88,11 @@ def check_rule(checker_data: models.CheckerData) -> None:
     if storyboard_elements is None:
         logging.error(
             "Cannot find Storyboard elements node in provided XOSC file. Skipping check"
+        )
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
         )
         return
 
@@ -137,16 +159,22 @@ def check_rule(checker_data: models.CheckerData) -> None:
 
             issue_id = checker_data.result.register_issue(
                 checker_bundle_name=constants.BUNDLE_NAME,
-                checker_id=reference_constants.CHECKER_ID,
+                checker_id=CHECKER_ID,
                 description="Issue flagging when a storyboardElementRef does not point to an existing element",
-                level=RULE_SEVERITY,
+                level=IssueSeverity.ERROR,
                 rule_uid=rule_uid,
             )
             issue_description = f"Storyboard element reference {current_storyboard_el_ref} not found among Storyboard elements "
             checker_data.result.add_xml_location(
                 checker_bundle_name=constants.BUNDLE_NAME,
-                checker_id=reference_constants.CHECKER_ID,
+                checker_id=CHECKER_ID,
                 issue_id=issue_id,
                 xpath=xpath,
                 description=issue_description,
             )
+
+    checker_data.result.set_checker_status(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        status=StatusType.COMPLETED,
+    )

--- a/qc_openscenario/checks/reference_checker/resolvable_traffic_signal_controller_by_traffic_signal_controller_ref.py
+++ b/qc_openscenario/checks/reference_checker/resolvable_traffic_signal_controller_by_traffic_signal_controller_ref.py
@@ -1,21 +1,14 @@
-import os, logging
+import logging
 
-from dataclasses import dataclass
-from typing import List
-
-from lxml import etree
-
-from qc_baselib import Configuration, Result, IssueSeverity
+from qc_baselib import IssueSeverity, StatusType
 
 from qc_openscenario import constants
-from qc_openscenario.schema import schema_files
 from qc_openscenario.checks import utils, models
 
-from qc_openscenario.checks.reference_checker import reference_constants
-from collections import deque, defaultdict
+from qc_openscenario.checks.reference_checker import reference_checker_precondition
 
+CHECKER_ID = "check_asam_xosc_reference_control_resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"
 MIN_RULE_VERSION = "1.2.0"
-RULE_SEVERITY = IssueSeverity.ERROR
 
 
 def check_rule(checker_data: models.CheckerData) -> None:
@@ -37,25 +30,44 @@ def check_rule(checker_data: models.CheckerData) -> None:
         "Executing resolvable_traffic_signal_controller_by_traffic_signal_controller_ref check"
     )
 
-    schema_version = checker_data.schema_version
-    if schema_version is None:
-        logging.info(f"- Version not found in the file. Skipping check")
-        return
-
-    if utils.compare_versions(schema_version, MIN_RULE_VERSION) < 0:
-        logging.info(
-            f"- Version {schema_version} is less than minimum required version {MIN_RULE_VERSION}. Skipping check"
-        )
-        return
+    checker_data.result.register_checker(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        description="The trafficSignalController according to the trafficSignalControllerRef property must exist within the scenarios RoadNetwork definition.",
+    )
 
     rule_uid = checker_data.result.register_rule(
         checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
+        checker_id=CHECKER_ID,
         emanating_entity="asam.net",
         standard="xosc",
         definition_setting=MIN_RULE_VERSION,
         rule_full_name="reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref",
     )
+
+    if not checker_data.result.all_checkers_completed_without_issue(
+        reference_checker_precondition.PRECONDITIONS
+    ):
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
+
+        return
+
+    schema_version = checker_data.schema_version
+    if (
+        schema_version is None
+        or utils.compare_versions(schema_version, MIN_RULE_VERSION) < 0
+    ):
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
+
+        return
 
     root = checker_data.input_file_xml_root
 
@@ -64,6 +76,11 @@ def check_rule(checker_data: models.CheckerData) -> None:
         logging.error(
             "Cannot find RoadNetwork node in provided XOSC file. Skipping check"
         )
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
+        )
         return
 
     # ts = traffic signal
@@ -71,6 +88,11 @@ def check_rule(checker_data: models.CheckerData) -> None:
     if ts_controllers is None:
         logging.error(
             "Cannot find TrafficSignalController nodes in RoadNetwork of provided XOSC file. Skipping check"
+        )
+        checker_data.result.set_checker_status(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            status=StatusType.SKIPPED,
         )
         return
 
@@ -89,15 +111,21 @@ def check_rule(checker_data: models.CheckerData) -> None:
 
             issue_id = checker_data.result.register_issue(
                 checker_bundle_name=constants.BUNDLE_NAME,
-                checker_id=reference_constants.CHECKER_ID,
+                checker_id=CHECKER_ID,
                 description="Issue flagging traffic signal controller reference not present in the declared RoadNetwork",
-                level=RULE_SEVERITY,
+                level=IssueSeverity.ERROR,
                 rule_uid=rule_uid,
             )
             checker_data.result.add_xml_location(
                 checker_bundle_name=constants.BUNDLE_NAME,
-                checker_id=reference_constants.CHECKER_ID,
+                checker_id=CHECKER_ID,
                 issue_id=issue_id,
                 xpath=xpath,
                 description=f"trafficSignalControllerRef at {xpath} with id {current_name} not found in RoadNetwork node",
             )
+
+    checker_data.result.set_checker_status(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        status=StatusType.COMPLETED,
+    )

--- a/qc_openscenario/checks/schema_checker/__init__.py
+++ b/qc_openscenario/checks/schema_checker/__init__.py
@@ -1,3 +1,2 @@
-from . import schema_constants as schema_constants
 from . import schema_checker as schema_checker
 from . import valid_schema as valid_schema

--- a/qc_openscenario/checks/schema_checker/schema_checker.py
+++ b/qc_openscenario/checks/schema_checker/schema_checker.py
@@ -1,64 +1,13 @@
 import logging
 
-from lxml import etree
 
-from qc_baselib import Configuration, Result, StatusType
-
-from qc_openscenario import constants
-from qc_openscenario.checks import utils, models
-from qc_openscenario.schema import schema_files
+from qc_openscenario.checks import models
 
 from qc_openscenario.checks.schema_checker import (
-    schema_constants,
     valid_schema,
 )
 
 
 def run_checks(checker_data: models.CheckerData) -> None:
     logging.info("Executing schema checks")
-
-    checker_data.result.register_checker(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=schema_constants.CHECKER_ID,
-        description="Check if xml properties of input file are properly set",
-        summary="",
-    )
-
-    if checker_data.input_file_xml_root is None:
-        logging.error(
-            f"Invalid xml input file. Checker {schema_constants.CHECKER_ID} skipped"
-        )
-        checker_data.result.set_checker_status(
-            checker_bundle_name=constants.BUNDLE_NAME,
-            checker_id=schema_constants.CHECKER_ID,
-            status=StatusType.SKIPPED,
-        )
-        return
-
-    if checker_data.schema_version not in schema_files.SCHEMA_FILES:
-
-        logging.error(
-            f"Version {checker_data.schema_version} unsupported. Checker {schema_constants.CHECKER_ID} skipped"
-        )
-        checker_data.result.set_checker_status(
-            checker_bundle_name=constants.BUNDLE_NAME,
-            checker_id=schema_constants.CHECKER_ID,
-            status=StatusType.SKIPPED,
-        )
-        return
-
-    rule_list = [valid_schema.check_rule]
-
-    for rule in rule_list:
-        rule(checker_data=checker_data)
-
-    logging.info(
-        f"Issues found - {checker_data.result.get_checker_issue_count(checker_bundle_name=constants.BUNDLE_NAME, checker_id=schema_constants.CHECKER_ID)}"
-    )
-
-    # TODO: Add logic to deal with error or to skip it
-    checker_data.result.set_checker_status(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=schema_constants.CHECKER_ID,
-        status=StatusType.COMPLETED,
-    )
+    valid_schema.check_rule(checker_data)

--- a/qc_openscenario/checks/schema_checker/schema_constants.py
+++ b/qc_openscenario/checks/schema_checker/schema_constants.py
@@ -1,1 +1,0 @@
-CHECKER_ID = "schema_xosc"

--- a/tests/data/allowed_operators/negative_example.xosc
+++ b/tests/data/allowed_operators/negative_example.xosc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSCENARIO xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <FileHeader revMajor="1" revMinor="2" date="2020-02-21T10:00:00"
+    <FileHeader revMajor="1" revMinor="3" date="2020-02-21T10:00:00"
         description="Test allowed operators"
         author="ASAM e.V." />
     <ParameterDeclarations />
@@ -13,8 +13,8 @@
                 <Private entityRef="Ego">
                     <PrivateAction>
                         <AppearanceAction>
-                            <!-- Power must be expressed with pow. "^" is not supported. -->
-                            <LightStateAction transitionTime="${2^3}">
+                            <!-- "_" is not an allowed operator. -->
+                            <LightStateAction transitionTime="${2_3}">
                                 <LightType>
                                     <VehicleLight vehicleLightType="fogLights" />
                                 </LightType>

--- a/tests/data/allowed_operators/negative_example_multiple.xosc
+++ b/tests/data/allowed_operators/negative_example_multiple.xosc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSCENARIO xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <FileHeader revMajor="1" revMinor="2" date="2020-02-21T10:00:00"
+    <FileHeader revMajor="1" revMinor="3" date="2020-02-21T10:00:00"
         description="Test allowed operators"
         author="ASAM e.V." />
     <ParameterDeclarations />
@@ -14,14 +14,50 @@
                 <Private entityRef="${round(1.3) % ceil(1.23) - sqrt(18.23} +7-321/65.32">
                     <PrivateAction>
                         <AppearanceAction>
-                            <!-- "powerer" not supported operation in expression -->
-                            <LightStateAction transitionTime="${powerer(2, 3)}">
+                            <LightStateAction transitionTime="${pow(2, 3)}">
                                 <LightType>
-                                    <!-- Character ^ not supported in expression -->
-                                    <VehicleLight vehicleLightType="${2*3+4^23}" />
+                                    <VehicleLight vehicleLightType="fogLights" />
                                 </LightType>
-                                <!-- Character ^ not supported in expression -->
-                                <LightState mode="${3^$foo}" />
+                                <LightState mode="on" />
+                            </LightStateAction>
+                        </AppearanceAction>
+                    </PrivateAction>
+                </Private>
+                <!-- "powerer" not supported operation in expression -->
+                <Private entityRef="${powerer(2, 3)}">
+                    <PrivateAction>
+                        <AppearanceAction>
+                            <LightStateAction transitionTime="${pow(2, 3)}">
+                                <LightType>
+                                    <VehicleLight vehicleLightType="fogLights" />
+                                </LightType>
+                                <LightState mode="on" />
+                            </LightStateAction>
+                        </AppearanceAction>
+                    </PrivateAction>
+                </Private>
+                <!-- Character ^ not supported in expression -->
+                <Private entityRef="${2*3+4^23}">
+                    <PrivateAction>
+                        <AppearanceAction>
+                            <LightStateAction transitionTime="${pow(2, 3)}">
+                                <LightType>
+                                    <VehicleLight vehicleLightType="fogLights" />
+                                </LightType>
+                                <LightState mode="on" />
+                            </LightStateAction>
+                        </AppearanceAction>
+                    </PrivateAction>
+                </Private>
+                <!-- Character ^ not supported in expression -->
+                <Private entityRef="${3^$foo}">
+                    <PrivateAction>
+                        <AppearanceAction>
+                            <LightStateAction transitionTime="${pow(2, 3)}">
+                                <LightType>
+                                    <VehicleLight vehicleLightType="fogLights" />
+                                </LightType>
+                                <LightState mode="on" />
                             </LightStateAction>
                         </AppearanceAction>
                     </PrivateAction>

--- a/tests/data/allowed_operators/negative_example_typo.xosc
+++ b/tests/data/allowed_operators/negative_example_typo.xosc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSCENARIO xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <FileHeader revMajor="1" revMinor="2" date="2020-02-21T10:00:00"
+    <FileHeader revMajor="1" revMinor="3" date="2020-02-21T10:00:00"
         description="Test allowed operators"
         author="ASAM e.V." />
     <ParameterDeclarations />

--- a/tests/data/allowed_operators/positive_example.param.xosc
+++ b/tests/data/allowed_operators/positive_example.param.xosc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSCENARIO xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <FileHeader revMajor="1" revMinor="2" date="2020-02-21T10:00:00"
+    <FileHeader revMajor="1" revMinor="3" date="2020-02-21T10:00:00"
         description="Test allowed operators"
         author="ASAM e.V." />
     <ParameterDeclarations />

--- a/tests/data/allowed_operators/positive_example.xosc
+++ b/tests/data/allowed_operators/positive_example.xosc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSCENARIO xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <FileHeader revMajor="1" revMinor="2" date="2020-02-21T10:00:00" description="Test allowed operators"
+    <FileHeader revMajor="1" revMinor="3" date="2020-02-21T10:00:00" description="Test allowed operators"
         author="ASAM e.V." />
     <ParameterDeclarations />
     <CatalogLocations />

--- a/tests/data/allowed_operators/positive_example_multiple.xosc
+++ b/tests/data/allowed_operators/positive_example_multiple.xosc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSCENARIO xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <FileHeader revMajor="1" revMinor="2" date="2020-02-21T10:00:00"
+    <FileHeader revMajor="1" revMinor="3" date="2020-02-21T10:00:00"
         description="Test allowed operators"
         author="ASAM e.V." />
     <ParameterDeclarations />
@@ -15,9 +15,45 @@
                         <AppearanceAction>
                             <LightStateAction transitionTime="${1 and 1}">
                                 <LightType>
-                                    <VehicleLight vehicleLightType="${1 or 0 and not 1}" />
+                                    <VehicleLight vehicleLightType="daytimeRunningLights" />
                                 </LightType>
-                                <LightState mode="${pow(2, 3)}" />
+                                <LightState mode="on" />
+                            </LightStateAction>
+                        </AppearanceAction>
+                    </PrivateAction>
+                </Private>
+                <Private entityRef="${1 or 0 and not 1}">
+                    <PrivateAction>
+                        <AppearanceAction>
+                            <LightStateAction transitionTime="${1 and 1}">
+                                <LightType>
+                                    <VehicleLight vehicleLightType="daytimeRunningLights" />
+                                </LightType>
+                                <LightState mode="on" />
+                            </LightStateAction>
+                        </AppearanceAction>
+                    </PrivateAction>
+                </Private>
+                <Private entityRef="${round(1.3) % ceil(1.23) - sqrt(18.23) +7-321/65.32">
+                    <PrivateAction>
+                        <AppearanceAction>
+                            <LightStateAction transitionTime="${1 and 1}">
+                                <LightType>
+                                    <VehicleLight vehicleLightType="daytimeRunningLights" />
+                                </LightType>
+                                <LightState mode="on" />
+                            </LightStateAction>
+                        </AppearanceAction>
+                    </PrivateAction>
+                </Private>
+                <Private entityRef="${round(1.3) % ceil(1.23) - sqrt(18.23) +7-321/65.32">
+                    <PrivateAction>
+                        <AppearanceAction>
+                            <LightStateAction transitionTime="${1 and 1}">
+                                <LightType>
+                                    <VehicleLight vehicleLightType="daytimeRunningLights" />
+                                </LightType>
+                                <LightState mode="on" />
                             </LightStateAction>
                         </AppearanceAction>
                     </PrivateAction>

--- a/tests/data/resolvable_signal_id_in_traffic_signal_state_action/reference_control.resolvable_signal_id_in_traffic_signal_state_action.negative.xosc
+++ b/tests/data/resolvable_signal_id_in_traffic_signal_state_action/reference_control.resolvable_signal_id_in_traffic_signal_state_action.negative.xosc
@@ -27,9 +27,7 @@
         <GlobalAction>
           <InfrastructureAction>
             <TrafficSignalAction>
-              <TrafficSignalStateAction name="12346" state="on;off;off">
-                <!--Inserted rule violation because signal 12346 doesn't exist in road network file.-->
-              </TrafficSignalStateAction>
+              <TrafficSignalStateAction name="12346" state="on;off;off"/>
             </TrafficSignalAction>
           </InfrastructureAction>
         </GlobalAction>

--- a/tests/data/resolvable_traffic_signal_controller_by_traffic_signal_controller_ref/reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref.negative.multiple.xosc
+++ b/tests/data/resolvable_traffic_signal_controller_by_traffic_signal_controller_ref/reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref.negative.multiple.xosc
@@ -45,12 +45,24 @@
             <TrafficSignalAction>
               <TrafficSignalControllerAction trafficSignalControllerRef="1234" phase="stop" />
             </TrafficSignalAction>
+          </InfrastructureAction>
+        </GlobalAction>
+        <GlobalAction>
+          <InfrastructureAction>
             <TrafficSignalAction>
               <TrafficSignalControllerAction trafficSignalControllerRef="4567" phase="stop" />
             </TrafficSignalAction>
+          </InfrastructureAction>
+        </GlobalAction>
+        <GlobalAction>
+          <InfrastructureAction>
             <TrafficSignalAction>
               <TrafficSignalControllerAction trafficSignalControllerRef="bar" phase="stop" />
             </TrafficSignalAction>
+          </InfrastructureAction>
+        </GlobalAction>
+        <GlobalAction>
+          <InfrastructureAction>
             <TrafficSignalAction>
               <TrafficSignalControllerAction trafficSignalControllerRef="0000" phase="stop" />
             </TrafficSignalAction>

--- a/tests/data/resolvable_traffic_signal_controller_by_traffic_signal_controller_ref/reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref.negative.xosc
+++ b/tests/data/resolvable_traffic_signal_controller_by_traffic_signal_controller_ref/reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref.negative.xosc
@@ -37,9 +37,7 @@
         <GlobalAction>
           <InfrastructureAction>
             <TrafficSignalAction>
-              <TrafficSignalControllerAction trafficSignalControllerRef="1235" phase="stop">
-                <!--Inserted rule violation because traffic signal controller 12346 doesn't exist in scenario.-->
-              </TrafficSignalControllerAction>
+              <TrafficSignalControllerAction trafficSignalControllerRef="1235" phase="stop"/>
             </TrafficSignalAction>
           </InfrastructureAction>
         </GlobalAction>

--- a/tests/data/resolvable_variable_reference/reference_control.resolvable_variable_reference.negative.multiple.xosc
+++ b/tests/data/resolvable_variable_reference/reference_control.resolvable_variable_reference.negative.multiple.xosc
@@ -35,14 +35,20 @@
                     <VariableAction variableRef="startingXPosition">
                         <SetAction value="1.0" />
                     </VariableAction>
+                </GlobalAction>
+                <GlobalAction>
                     <VariableAction variableRef="startingYPosition">
                         <SetAction value="1.0" />
                     </VariableAction>
+                </GlobalAction>
+                <GlobalAction>
                     <!-- Inserted rule violation since "unknownReferenceForYPosition" does not
                     exist. -->
                     <VariableAction variableRef="unknownReferenceForYPosition">
                         <SetAction value="1.0" />
                     </VariableAction>
+                </GlobalAction>
+                <GlobalAction>
                     <!-- Inserted rule violation since "foo" does not
                     exist. -->
                     <VariableAction variableRef="foo">

--- a/tests/data/uniquely_resolvable_entity_references/long_catalog_negative.xosc
+++ b/tests/data/uniquely_resolvable_entity_references/long_catalog_negative.xosc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <OpenSCENARIO>
-    <FileHeader description="Vehicle Catalog" author="ASAM" revMajor="1" revMinor="2"
+    <FileHeader description="Vehicle Catalog" author="ASAM" revMajor="1" revMinor="3"
         date="2023-11-15T11:00:00.000000" />
     <Catalog name="VehicleCatalog_1">
         <Vehicle name="car_white" vehicleCategory="car">
@@ -22,13 +22,123 @@
                     filepath="../../../external/delivery/esmini-noosg/resources/osgb/car_white.osgb" />
             </Properties>
         </Vehicle>
-        <Vehicle name="car_red" />
+        <Vehicle name="car_red" vehicleCategory="car">
+            <BoundingBox>
+                <Center x="1.4" y="0.0" z="0.9" />
+                <Dimensions width="2.0" length="5.0" height="1.8" />
+            </BoundingBox>
+            <Performance maxSpeed="69" maxDeceleration="30" maxAcceleration="5" />
+            <Axles>
+                <FrontAxle maxSteering="30" wheelDiameter="0.8" trackWidth="1.68" positionX="2.98"
+                    positionZ="0.4" />
+                <RearAxle maxSteering="30" wheelDiameter="0.8" trackWidth="1.68" positionX="0"
+                    positionZ="0.4" />
+            </Axles>
+            <Properties>
+                <Property name="control" value="internal" />
+                <Property name="model_id" value="0" />
+                <File
+                    filepath="../../../external/delivery/esmini-noosg/resources/osgb/car_white.osgb" />
+            </Properties>
+        </Vehicle>
         <Controller name="abc" />
         <Controller name="controller2" />
-        <Maneuver name="abc" />
-        <Maneuver name="maneuver2" />
-        <Route name="route1" />
-        <Route name="route2" />
+        <Maneuver name="abc">
+            <Event name="Event1" priority="override">
+                <Action name="Action1">
+                    <PrivateAction>
+                        <LateralAction>
+                            <LaneChangeAction targetLaneOffset="-0.0361164093018">
+                                <LaneChangeActionDynamics dynamicsDimension="distance"
+                                    dynamicsShape="cubic" value="54.8254917969" />
+                                <LaneChangeTarget>
+                                    <RelativeTargetLane entityRef="Ego" value="0" />
+                                </LaneChangeTarget>
+                            </LaneChangeAction>
+                        </LateralAction>
+                    </PrivateAction>
+                </Action>
+                <StartTrigger>
+                    <ConditionGroup>
+                        <Condition name="StartCondition1" delay="0" conditionEdge="rising">
+                            <ByEntityCondition>
+                                <TriggeringEntities triggeringEntitiesRule="any">
+                                    <EntityRef entityRef="$owner" />
+                                </TriggeringEntities>
+                                <EntityCondition>
+                                    <DistanceCondition value="20.0" freespace="false"
+                                        coordinateSystem="road" rule="greaterThan">
+                                        <Position>
+                                            <RelativeObjectPosition entityRef="Ego" dx="0" dy="0" />
+                                        </Position>
+                                    </DistanceCondition>
+                                </EntityCondition>
+                            </ByEntityCondition>
+                        </Condition>
+                    </ConditionGroup>
+                </StartTrigger>
+            </Event>
+        </Maneuver>
+        <Maneuver name="Maneuver2">
+            <Event name="Event1" priority="override">
+                <Action name="Action1">
+                    <PrivateAction>
+                        <LateralAction>
+                            <LaneChangeAction targetLaneOffset="-0.0361164093018">
+                                <LaneChangeActionDynamics dynamicsDimension="distance"
+                                    dynamicsShape="cubic" value="54.8254917969" />
+                                <LaneChangeTarget>
+                                    <RelativeTargetLane entityRef="Ego" value="0" />
+                                </LaneChangeTarget>
+                            </LaneChangeAction>
+                        </LateralAction>
+                    </PrivateAction>
+                </Action>
+                <StartTrigger>
+                    <ConditionGroup>
+                        <Condition name="StartCondition1" delay="0" conditionEdge="rising">
+                            <ByEntityCondition>
+                                <TriggeringEntities triggeringEntitiesRule="any">
+                                    <EntityRef entityRef="$owner" />
+                                </TriggeringEntities>
+                                <EntityCondition>
+                                    <DistanceCondition value="20.0" freespace="false"
+                                        coordinateSystem="road" rule="greaterThan">
+                                        <Position>
+                                            <RelativeObjectPosition entityRef="Ego" dx="0" dy="0" />
+                                        </Position>
+                                    </DistanceCondition>
+                                </EntityCondition>
+                            </ByEntityCondition>
+                        </Condition>
+                    </ConditionGroup>
+                </StartTrigger>
+            </Event>
+        </Maneuver>
+        <Route name="route1" closed="false">
+            <Waypoint routeStrategy="shortest">
+                <Position>
+                    <LanePosition roadId="3" laneId="-1" offset="0" s="70" />
+                </Position>
+            </Waypoint>
+            <Waypoint routeStrategy="shortest">
+                <Position>
+                    <LanePosition roadId="1" laneId="-1" offset="0" s="0" />
+                </Position>
+            </Waypoint>
+        </Route>
+        <Route name="route2" closed="false">
+            <Waypoint routeStrategy="shortest">
+                <Position>
+                    <LanePosition roadId="3" laneId="-1" offset="0" s="70" />
+                </Position>
+            </Waypoint>
+            <Waypoint routeStrategy="shortest">
+                <Position>
+                    <LanePosition roadId="1" laneId="-1" offset="0" s="0" />
+                </Position>
+            </Waypoint>
+        </Route>
 
     </Catalog>
 </OpenSCENARIO>

--- a/tests/data/uniquely_resolvable_entity_references/long_catalog_positive.xosc
+++ b/tests/data/uniquely_resolvable_entity_references/long_catalog_positive.xosc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <OpenSCENARIO>
-    <FileHeader description="Vehicle Catalog" author="ASAM" revMajor="1" revMinor="2"
+    <FileHeader description="Vehicle Catalog" author="ASAM" revMajor="1" revMinor="3"
         date="2023-11-15T11:00:00.000000" />
     <Catalog name="VehicleCatalog_1">
         <Vehicle name="car_white" vehicleCategory="car">
@@ -22,13 +22,123 @@
                     filepath="../../../external/delivery/esmini-noosg/resources/osgb/car_white.osgb" />
             </Properties>
         </Vehicle>
-        <Vehicle name="car_red" />
+        <Vehicle name="car_red" vehicleCategory="car">
+            <BoundingBox>
+                <Center x="1.4" y="0.0" z="0.9" />
+                <Dimensions width="2.0" length="5.0" height="1.8" />
+            </BoundingBox>
+            <Performance maxSpeed="69" maxDeceleration="30" maxAcceleration="5" />
+            <Axles>
+                <FrontAxle maxSteering="30" wheelDiameter="0.8" trackWidth="1.68" positionX="2.98"
+                    positionZ="0.4" />
+                <RearAxle maxSteering="30" wheelDiameter="0.8" trackWidth="1.68" positionX="0"
+                    positionZ="0.4" />
+            </Axles>
+            <Properties>
+                <Property name="control" value="internal" />
+                <Property name="model_id" value="0" />
+                <File
+                    filepath="../../../external/delivery/esmini-noosg/resources/osgb/car_white.osgb" />
+            </Properties>
+        </Vehicle>
         <Controller name="controller1" />
         <Controller name="controller2" />
-        <Maneuver name="maneuver1" />
-        <Maneuver name="maneuver2" />
-        <Route name="route1" />
-        <Route name="route2" />
+        <Maneuver name="Maneuver1">
+            <Event name="Event1" priority="override">
+                <Action name="Action1">
+                    <PrivateAction>
+                        <LateralAction>
+                            <LaneChangeAction targetLaneOffset="-0.0361164093018">
+                                <LaneChangeActionDynamics dynamicsDimension="distance"
+                                    dynamicsShape="cubic" value="54.8254917969" />
+                                <LaneChangeTarget>
+                                    <RelativeTargetLane entityRef="Ego" value="0" />
+                                </LaneChangeTarget>
+                            </LaneChangeAction>
+                        </LateralAction>
+                    </PrivateAction>
+                </Action>
+                <StartTrigger>
+                    <ConditionGroup>
+                        <Condition name="StartCondition1" delay="0" conditionEdge="rising">
+                            <ByEntityCondition>
+                                <TriggeringEntities triggeringEntitiesRule="any">
+                                    <EntityRef entityRef="$owner" />
+                                </TriggeringEntities>
+                                <EntityCondition>
+                                    <DistanceCondition value="20.0" freespace="false"
+                                        coordinateSystem="road" rule="greaterThan">
+                                        <Position>
+                                            <RelativeObjectPosition entityRef="Ego" dx="0" dy="0" />
+                                        </Position>
+                                    </DistanceCondition>
+                                </EntityCondition>
+                            </ByEntityCondition>
+                        </Condition>
+                    </ConditionGroup>
+                </StartTrigger>
+            </Event>
+        </Maneuver>
+        <Maneuver name="Maneuver2">
+            <Event name="Event1" priority="override">
+                <Action name="Action1">
+                    <PrivateAction>
+                        <LateralAction>
+                            <LaneChangeAction targetLaneOffset="-0.0361164093018">
+                                <LaneChangeActionDynamics dynamicsDimension="distance"
+                                    dynamicsShape="cubic" value="54.8254917969" />
+                                <LaneChangeTarget>
+                                    <RelativeTargetLane entityRef="Ego" value="0" />
+                                </LaneChangeTarget>
+                            </LaneChangeAction>
+                        </LateralAction>
+                    </PrivateAction>
+                </Action>
+                <StartTrigger>
+                    <ConditionGroup>
+                        <Condition name="StartCondition1" delay="0" conditionEdge="rising">
+                            <ByEntityCondition>
+                                <TriggeringEntities triggeringEntitiesRule="any">
+                                    <EntityRef entityRef="$owner" />
+                                </TriggeringEntities>
+                                <EntityCondition>
+                                    <DistanceCondition value="20.0" freespace="false"
+                                        coordinateSystem="road" rule="greaterThan">
+                                        <Position>
+                                            <RelativeObjectPosition entityRef="Ego" dx="0" dy="0" />
+                                        </Position>
+                                    </DistanceCondition>
+                                </EntityCondition>
+                            </ByEntityCondition>
+                        </Condition>
+                    </ConditionGroup>
+                </StartTrigger>
+            </Event>
+        </Maneuver>
+        <Route name="route1" closed="false">
+            <Waypoint routeStrategy="shortest">
+                <Position>
+                    <LanePosition roadId="3" laneId="-1" offset="0" s="70" />
+                </Position>
+            </Waypoint>
+            <Waypoint routeStrategy="shortest">
+                <Position>
+                    <LanePosition roadId="1" laneId="-1" offset="0" s="0" />
+                </Position>
+            </Waypoint>
+        </Route>
+        <Route name="route2" closed="false">
+            <Waypoint routeStrategy="shortest">
+                <Position>
+                    <LanePosition roadId="3" laneId="-1" offset="0" s="70" />
+                </Position>
+            </Waypoint>
+            <Waypoint routeStrategy="shortest">
+                <Position>
+                    <LanePosition roadId="1" laneId="-1" offset="0" s="0" />
+                </Position>
+            </Waypoint>
+        </Route>
 
     </Catalog>
 </OpenSCENARIO>

--- a/tests/data/valid_schema/xml.valid_schema.negative.xosc
+++ b/tests/data/valid_schema/xml.valid_schema.negative.xosc
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OpenSCENARIO xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Schema/OpenSCENARIO.xsd">
-  <!-- FileHeader must be defined according to the schema. -->
-  <!-- <FileHeader author="ASAM e.V." date="2021-02-05T18:50:17" description="Simple Overtaker example" revMajor="1" revMinor="3"/> -->
+  <FileHeader author="ASAM e.V." date="2021-02-05T18:50:17" description="Simple Overtaker example" revMajor="1" revMinor="3"/>
   <ParameterDeclarations/>
   <CatalogLocations/>
-  <RoadNetwork/>
+  <!-- Missing road network -->
+  <!-- <RoadNetwork/> -->
   <Entities>
     <ScenarioObject name="Vehicle 1">
       <Vehicle name="Vehicle 1" vehicleCategory="car">

--- a/tests/test_basic_checks.py
+++ b/tests/test_basic_checks.py
@@ -1,8 +1,8 @@
 import os
 import pytest
 import test_utils
-from qc_openscenario import constants
-from qc_baselib import Result, IssueSeverity
+from qc_baselib import Result, IssueSeverity, StatusType
+from qc_openscenario.checks import basic_checker
 
 
 def test_valid_xml_document_positive(
@@ -19,6 +19,10 @@ def test_valid_xml_document_positive(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
+    assert (
+        result.get_checker_status(basic_checker.valid_xml_document.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
     assert (
         len(result.get_issues_by_rule_uid("asam.net:xosc:1.0.0:xml.valid_xml_document"))
         == 0
@@ -40,6 +44,11 @@ def test_valid_xml_document_negative(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(basic_checker.valid_xml_document.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
 
     xml_doc_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.0.0:xml.valid_xml_document"
@@ -63,6 +72,7 @@ def test_parametric_input_xodr(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
+    assert result.all_checkers_completed() == True
     assert result.get_issue_count() == 0
     test_utils.cleanup_files()
 
@@ -81,6 +91,7 @@ def test_parametric_entity_ref(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
+    assert result.all_checkers_completed() == True
     assert result.get_issue_count() == 0
     test_utils.cleanup_files()
 
@@ -118,6 +129,11 @@ def test_root_tag_is_openscenario_positive(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
+        result.get_checker_status(basic_checker.root_tag_is_openscenario.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
+
+    assert (
         len(
             result.get_issues_by_rule_uid(
                 "asam.net:xosc:1.0.0:xml.root_tag_is_openscenario"
@@ -143,6 +159,11 @@ def test_root_tag_is_openscenario_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
+    assert (
+        result.get_checker_status(basic_checker.valid_xml_document.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
+
     xml_doc_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.0.0:xml.root_tag_is_openscenario"
     )
@@ -164,6 +185,11 @@ def test_fileheader_is_present_positive(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(basic_checker.fileheader_is_present.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
 
     assert (
         len(
@@ -191,6 +217,11 @@ def test_fileheader_is_present_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
+    assert (
+        result.get_checker_status(basic_checker.fileheader_is_present.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
+
     xml_doc_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.0.0:xml.fileheader_is_present"
     )
@@ -199,7 +230,7 @@ def test_fileheader_is_present_negative(
     test_utils.cleanup_files()
 
 
-def test_version_is_defined__positive(
+def test_version_is_defined_positive(
     monkeypatch,
 ) -> None:
     base_path = "tests/data/version_is_defined/"
@@ -212,6 +243,11 @@ def test_version_is_defined__positive(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(basic_checker.version_is_defined.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
 
     assert (
         len(result.get_issues_by_rule_uid("asam.net:xosc:1.0.0:xml.version_is_defined"))
@@ -235,6 +271,11 @@ def test_version_is_defined_negative_attr(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
+    assert (
+        result.get_checker_status(basic_checker.version_is_defined.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
+
     xml_doc_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.0.0:xml.version_is_defined"
     )
@@ -256,6 +297,11 @@ def test_version_is_defined_negative_type(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(basic_checker.version_is_defined.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
 
     xml_doc_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.0.0:xml.version_is_defined"

--- a/tests/test_basic_checks.py
+++ b/tests/test_basic_checks.py
@@ -2,7 +2,6 @@ import os
 import pytest
 import test_utils
 from qc_openscenario import constants
-from qc_openscenario.checks.basic_checker import basic_constants
 from qc_baselib import Result, IssueSeverity
 
 

--- a/tests/test_data_type_checks.py
+++ b/tests/test_data_type_checks.py
@@ -1,9 +1,8 @@
 import os
 import pytest
 import test_utils
-from qc_openscenario import constants
-from qc_openscenario.checks.data_type_checker import data_type_constants
-from qc_baselib import Result, IssueSeverity
+from qc_baselib import Result, IssueSeverity, StatusType
+from qc_openscenario.checks import data_type_checker
 
 
 def test_positive_duration_in_phase_positive(
@@ -19,6 +18,13 @@ def test_positive_duration_in_phase_positive(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            data_type_checker.positive_duration_in_phase.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
 
     assert (
         len(
@@ -47,6 +53,13 @@ def test_positive_duration_in_phase_positive_parameter(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
+        result.get_checker_status(
+            data_type_checker.positive_duration_in_phase.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
+    assert (
         len(
             result.get_issues_by_rule_uid(
                 "asam.net:xosc:1.2.0:data_type.positive_duration_in_phase"
@@ -72,9 +85,11 @@ def test_positive_duration_in_phase_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=data_type_constants.CHECKER_ID,
+    assert (
+        result.get_checker_status(
+            data_type_checker.positive_duration_in_phase.CHECKER_ID
+        )
+        == StatusType.COMPLETED
     )
 
     data_type_issues = result.get_issues_by_rule_uid(
@@ -99,9 +114,11 @@ def test_positive_duration_in_phase_negative_parameter(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=data_type_constants.CHECKER_ID,
+    assert (
+        result.get_checker_status(
+            data_type_checker.positive_duration_in_phase.CHECKER_ID
+        )
+        == StatusType.COMPLETED
     )
 
     data_type_issues = result.get_issues_by_rule_uid(
@@ -125,6 +142,11 @@ def test_allowed_operators_positive(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(data_type_checker.allowed_operators.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
 
     assert (
         len(
@@ -153,6 +175,11 @@ def test_allowed_operators_positive_param(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
+        result.get_checker_status(data_type_checker.allowed_operators.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
+
+    assert (
         len(
             result.get_issues_by_rule_uid(
                 "asam.net:xosc:1.2.0:data_type.allowed_operators"
@@ -177,6 +204,11 @@ def test_allowed_operators_positive_multiple(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(data_type_checker.allowed_operators.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
 
     assert (
         len(
@@ -205,6 +237,11 @@ def test_trailer_connect_standard_example(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
+        result.get_checker_status(data_type_checker.allowed_operators.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
+
+    assert (
         len(
             result.get_issues_by_rule_uid(
                 "asam.net:xosc:1.2.0:data_type.allowed_operators"
@@ -230,9 +267,9 @@ def test_allowed_operators_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=data_type_constants.CHECKER_ID,
+    assert (
+        result.get_checker_status(data_type_checker.allowed_operators.CHECKER_ID)
+        == StatusType.COMPLETED
     )
 
     data_type_issues = result.get_issues_by_rule_uid(
@@ -257,9 +294,9 @@ def test_allowed_operators_negative_typo(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=data_type_constants.CHECKER_ID,
+    assert (
+        result.get_checker_status(data_type_checker.allowed_operators.CHECKER_ID)
+        == StatusType.COMPLETED
     )
 
     data_type_issues = result.get_issues_by_rule_uid(
@@ -284,9 +321,9 @@ def test_allowed_operators_negative_multiple(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=data_type_constants.CHECKER_ID,
+    assert (
+        result.get_checker_status(data_type_checker.allowed_operators.CHECKER_ID)
+        == StatusType.COMPLETED
     )
 
     data_type_issues = result.get_issues_by_rule_uid(
@@ -318,6 +355,13 @@ def test_non_negative_transition_time_in_light_state_action_positive(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
+        result.get_checker_status(
+            data_type_checker.non_negative_transition_time_in_light_state_action.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
+    assert (
         len(
             result.get_issues_by_rule_uid(
                 "asam.net:xosc:1.2.0:data_type.non_negative_transition_time_in_light_state_action"
@@ -343,9 +387,11 @@ def test_non_negative_transition_time_in_light_state_action_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=data_type_constants.CHECKER_ID,
+    assert (
+        result.get_checker_status(
+            data_type_checker.non_negative_transition_time_in_light_state_action.CHECKER_ID
+        )
+        == StatusType.COMPLETED
     )
 
     data_type_issues = result.get_issues_by_rule_uid(
@@ -370,9 +416,11 @@ def test_non_negative_transition_time_in_light_state_action_negative_param(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=data_type_constants.CHECKER_ID,
+    assert (
+        result.get_checker_status(
+            data_type_checker.non_negative_transition_time_in_light_state_action.CHECKER_ID
+        )
+        == StatusType.COMPLETED
     )
 
     data_type_issues = result.get_issues_by_rule_uid(

--- a/tests/test_parameters_checks.py
+++ b/tests/test_parameters_checks.py
@@ -1,9 +1,8 @@
 import os
 import pytest
 import test_utils
-from qc_openscenario import constants
-from qc_openscenario.checks.parameters_checker import parameters_constants
-from qc_baselib import Result, IssueSeverity
+from qc_baselib import Result, IssueSeverity, StatusType
+from qc_openscenario.checks import parameters_checker
 
 
 def test_valid_parameter_declaration_in_catalogs_positive(
@@ -21,6 +20,13 @@ def test_valid_parameter_declaration_in_catalogs_positive(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            parameters_checker.valid_parameter_declaration_in_catalogs.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
 
     assert (
         len(
@@ -50,9 +56,11 @@ def test_valid_parameter_declaration_in_catalogs_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=parameters_constants.CHECKER_ID,
+    assert (
+        result.get_checker_status(
+            parameters_checker.valid_parameter_declaration_in_catalogs.CHECKER_ID
+        )
+        == StatusType.COMPLETED
     )
 
     parameters_issues = result.get_issues_by_rule_uid(
@@ -79,9 +87,11 @@ def test_valid_parameter_declaration_in_catalogs_negative_no_default(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=parameters_constants.CHECKER_ID,
+    assert (
+        result.get_checker_status(
+            parameters_checker.valid_parameter_declaration_in_catalogs.CHECKER_ID
+        )
+        == StatusType.COMPLETED
     )
 
     parameters_issues = result.get_issues_by_rule_uid(
@@ -108,9 +118,11 @@ def test_valid_parameter_declaration_in_catalogs_negative_multiple(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=parameters_constants.CHECKER_ID,
+    assert (
+        result.get_checker_status(
+            parameters_checker.valid_parameter_declaration_in_catalogs.CHECKER_ID
+        )
+        == StatusType.COMPLETED
     )
 
     parameters_issues = result.get_issues_by_rule_uid(

--- a/tests/test_reference_checks.py
+++ b/tests/test_reference_checks.py
@@ -2,7 +2,6 @@ import os
 import pytest
 import test_utils
 from qc_openscenario import constants
-from qc_openscenario.checks.reference_checker import reference_constants
 from qc_baselib import Result, IssueSeverity
 
 
@@ -20,10 +19,6 @@ def test_uniquely_resolvable_positive1(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     assert (
         len(
             result.get_issues_by_rule_uid(
@@ -50,10 +45,6 @@ def test_uniquely_resolvable_positive2(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     assert (
         len(
             result.get_issues_by_rule_uid(
@@ -102,10 +93,6 @@ def test_long_catalog_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"
     )
@@ -128,10 +115,6 @@ def test_long_catalog_positive(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     assert (
         len(
             result.get_issues_by_rule_uid(
@@ -156,10 +139,6 @@ def test_minimum_version(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     # 0 issues because minumum version is not met and the check is not performed
     # (even if it is a negative sample)
     assert (
@@ -186,10 +165,6 @@ def test_traffic_signal_state_positive(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     assert (
         len(
             result.get_issues_by_rule_uid(
@@ -214,11 +189,6 @@ def test_traffic_signal_state_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
-
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"
     )
@@ -241,10 +211,6 @@ def test_traffic_signal_controller_positive(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     assert (
         len(
             result.get_issues_by_rule_uid(
@@ -269,11 +235,6 @@ def test_traffic_signal_controller_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
-
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"
     )
@@ -295,11 +256,6 @@ def test_traffic_signal_controller_multiple_negative(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
-
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
 
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"
@@ -328,10 +284,6 @@ def test_valid_actor_reference_in_private_actions_positive(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     assert (
         len(
             result.get_issues_by_rule_uid(
@@ -356,10 +308,6 @@ def test_valid_actor_reference_in_private_actions_positive_with_entity(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     assert (
         len(
             result.get_issues_by_rule_uid(
@@ -386,11 +334,6 @@ def test_valid_actor_reference_in_private_actions_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
-
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"
     )
@@ -413,10 +356,6 @@ def test_resolvable_entity_reference_positive(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     assert (
         len(
             result.get_issues_by_rule_uid(
@@ -441,11 +380,6 @@ def test_resolvable_entity_reference_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
-
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"
     )
@@ -469,11 +403,6 @@ def test_resolvable_entity_reference_negative_multiple(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
-
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
 
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"
@@ -500,10 +429,6 @@ def test_resolvable_variable_reference_positive(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     assert (
         len(
             result.get_issues_by_rule_uid(
@@ -528,11 +453,6 @@ def test_resolvable_variable_reference_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
-
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"
     )
@@ -556,11 +476,6 @@ def test_resolvable_variable_reference_multiple(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
-
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
 
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"
@@ -589,10 +504,6 @@ def test_resolvable_storyboard_element_reference_positive(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     assert (
         len(
             result.get_issues_by_rule_uid(
@@ -619,10 +530,6 @@ def test_resolvable_storyboard_element_reference_positive_parameter(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     assert (
         len(
             result.get_issues_by_rule_uid(
@@ -646,11 +553,6 @@ def test_resolvable_storyboard_element_reference_negative(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
-
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
 
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_storyboard_element_reference"
@@ -680,11 +582,6 @@ def test_resolvable_storyboard_element_reference_negative_parameter(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
-
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_storyboard_element_reference"
     )
@@ -707,10 +604,6 @@ def test_unique_element_names_on_same_level_positive(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     assert (
         len(
             result.get_issues_by_rule_uid(
@@ -735,10 +628,6 @@ def test_unique_element_names_on_same_level_positive_multiple(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
     assert (
         len(
             result.get_issues_by_rule_uid(
@@ -763,11 +652,6 @@ def test_unique_element_names_on_same_level_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
-
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.unique_element_names_on_same_level"
     )
@@ -789,11 +673,6 @@ def test_unique_element_names_on_same_level_negative_multiple(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
-
-    _ = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=reference_constants.CHECKER_ID,
-    )
 
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.unique_element_names_on_same_level"

--- a/tests/test_reference_checks.py
+++ b/tests/test_reference_checks.py
@@ -1,8 +1,8 @@
 import os
 import pytest
 import test_utils
-from qc_openscenario import constants
-from qc_baselib import Result, IssueSeverity
+from qc_baselib import Result, IssueSeverity, StatusType
+from qc_openscenario.checks import reference_checker
 
 
 def test_uniquely_resolvable_positive1(
@@ -18,6 +18,13 @@ def test_uniquely_resolvable_positive1(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            reference_checker.uniquely_resolvable_entity_references.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
 
     assert (
         len(
@@ -46,6 +53,13 @@ def test_uniquely_resolvable_positive2(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
+        result.get_checker_status(
+            reference_checker.uniquely_resolvable_entity_references.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
+    assert (
         len(
             result.get_issues_by_rule_uid(
                 "asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"
@@ -71,6 +85,13 @@ def test_uniquely_resolvable_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
+    assert (
+        result.get_checker_status(
+            reference_checker.uniquely_resolvable_entity_references.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"
     )
@@ -92,6 +113,13 @@ def test_long_catalog_negative(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            reference_checker.uniquely_resolvable_entity_references.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
 
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"
@@ -116,6 +144,13 @@ def test_long_catalog_positive(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
+        result.get_checker_status(
+            reference_checker.uniquely_resolvable_entity_references.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
+    assert (
         len(
             result.get_issues_by_rule_uid(
                 "asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"
@@ -138,6 +173,13 @@ def test_minimum_version(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            reference_checker.uniquely_resolvable_entity_references.CHECKER_ID
+        )
+        == StatusType.SKIPPED
+    )
 
     # 0 issues because minumum version is not met and the check is not performed
     # (even if it is a negative sample)
@@ -166,6 +208,13 @@ def test_traffic_signal_state_positive(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
+        result.get_checker_status(
+            reference_checker.resolvable_signal_id_in_traffic_signal_state_action.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
+    assert (
         len(
             result.get_issues_by_rule_uid(
                 "asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"
@@ -189,6 +238,13 @@ def test_traffic_signal_state_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
+    assert (
+        result.get_checker_status(
+            reference_checker.resolvable_signal_id_in_traffic_signal_state_action.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"
     )
@@ -210,6 +266,13 @@ def test_traffic_signal_controller_positive(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            reference_checker.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
 
     assert (
         len(
@@ -235,6 +298,13 @@ def test_traffic_signal_controller_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
+    assert (
+        result.get_checker_status(
+            reference_checker.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"
     )
@@ -256,6 +326,13 @@ def test_traffic_signal_controller_multiple_negative(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            reference_checker.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
 
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"
@@ -285,6 +362,13 @@ def test_valid_actor_reference_in_private_actions_positive(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
+        result.get_checker_status(
+            reference_checker.valid_actor_reference_in_private_actions.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
+    assert (
         len(
             result.get_issues_by_rule_uid(
                 "asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"
@@ -307,6 +391,13 @@ def test_valid_actor_reference_in_private_actions_positive_with_entity(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            reference_checker.valid_actor_reference_in_private_actions.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
 
     assert (
         len(
@@ -334,9 +425,17 @@ def test_valid_actor_reference_in_private_actions_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
+    assert (
+        result.get_checker_status(
+            reference_checker.valid_actor_reference_in_private_actions.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"
     )
+
     assert len(reference_issues) == 1
     assert reference_issues[0].level == IssueSeverity.ERROR
     test_utils.cleanup_files()
@@ -355,6 +454,13 @@ def test_resolvable_entity_reference_positive(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            reference_checker.resolvable_entity_references.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
 
     assert (
         len(
@@ -380,6 +486,13 @@ def test_resolvable_entity_reference_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
+    assert (
+        result.get_checker_status(
+            reference_checker.resolvable_entity_references.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"
     )
@@ -403,6 +516,13 @@ def test_resolvable_entity_reference_negative_multiple(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            reference_checker.resolvable_entity_references.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
 
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"
@@ -430,6 +550,13 @@ def test_resolvable_variable_reference_positive(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
+        result.get_checker_status(
+            reference_checker.resolvable_entity_references.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
+    assert (
         len(
             result.get_issues_by_rule_uid(
                 "asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"
@@ -452,6 +579,13 @@ def test_resolvable_variable_reference_negative(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            reference_checker.resolvable_variable_reference.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
 
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"
@@ -476,6 +610,13 @@ def test_resolvable_variable_reference_multiple(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            reference_checker.resolvable_variable_reference.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
 
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"
@@ -505,6 +646,13 @@ def test_resolvable_storyboard_element_reference_positive(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
+        result.get_checker_status(
+            reference_checker.resolvable_storyboard_element_reference.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
+    assert (
         len(
             result.get_issues_by_rule_uid(
                 "asam.net:xosc:1.2.0:reference_control.resolvable_storyboard_element_reference"
@@ -531,6 +679,13 @@ def test_resolvable_storyboard_element_reference_positive_parameter(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
+        result.get_checker_status(
+            reference_checker.resolvable_storyboard_element_reference.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
+    assert (
         len(
             result.get_issues_by_rule_uid(
                 "asam.net:xosc:1.2.0:reference_control.resolvable_storyboard_element_reference"
@@ -553,6 +708,13 @@ def test_resolvable_storyboard_element_reference_negative(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            reference_checker.resolvable_storyboard_element_reference.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
 
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_storyboard_element_reference"
@@ -582,6 +744,13 @@ def test_resolvable_storyboard_element_reference_negative_parameter(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
+    assert (
+        result.get_checker_status(
+            reference_checker.resolvable_storyboard_element_reference.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.resolvable_storyboard_element_reference"
     )
@@ -603,6 +772,13 @@ def test_unique_element_names_on_same_level_positive(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            reference_checker.unique_element_names_on_same_level.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
 
     assert (
         len(
@@ -629,6 +805,13 @@ def test_unique_element_names_on_same_level_positive_multiple(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
+        result.get_checker_status(
+            reference_checker.unique_element_names_on_same_level.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
+    assert (
         len(
             result.get_issues_by_rule_uid(
                 "asam.net:xosc:1.2.0:reference_control.unique_element_names_on_same_level"
@@ -652,6 +835,13 @@ def test_unique_element_names_on_same_level_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
+    assert (
+        result.get_checker_status(
+            reference_checker.unique_element_names_on_same_level.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
+
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.unique_element_names_on_same_level"
     )
@@ -673,6 +863,13 @@ def test_unique_element_names_on_same_level_negative_multiple(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(
+            reference_checker.unique_element_names_on_same_level.CHECKER_ID
+        )
+        == StatusType.COMPLETED
+    )
 
     reference_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.2.0:reference_control.unique_element_names_on_same_level"

--- a/tests/test_schema_checks.py
+++ b/tests/test_schema_checks.py
@@ -1,8 +1,8 @@
 import os
 import pytest
 import test_utils
-from qc_openscenario import constants
-from qc_baselib import Result, IssueSeverity
+from qc_baselib import Result, IssueSeverity, StatusType
+from qc_openscenario.checks import schema_checker
 
 
 def test_valid_schema_positive(
@@ -18,6 +18,11 @@ def test_valid_schema_positive(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(schema_checker.valid_schema.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
 
     assert (
         len(result.get_issues_by_rule_uid("asam.net:xosc:1.0.0:xml.valid_schema")) == 0
@@ -41,7 +46,12 @@ def test_valid_schema_negative(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
-        len(result.get_issues_by_rule_uid("asam.net:xosc:1.0.0:xml.valid_schema")) == 0
+        result.get_checker_status(schema_checker.valid_schema.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
+
+    assert (
+        len(result.get_issues_by_rule_uid("asam.net:xosc:1.0.0:xml.valid_schema")) == 1
     )
     test_utils.cleanup_files()
 
@@ -59,6 +69,11 @@ def test_unsupported_schema_version(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(schema_checker.valid_schema.CHECKER_ID)
+        == StatusType.SKIPPED
+    )
 
     assert (
         len(result.get_issues_by_rule_uid("asam.net:xosc:1.0.0:xml.valid_schema")) == 0
@@ -79,6 +94,11 @@ def test_invalid_schema(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        result.get_checker_status(schema_checker.valid_schema.CHECKER_ID)
+        == StatusType.COMPLETED
+    )
 
     xml_schema_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.0.0:xml.valid_schema"

--- a/tests/test_schema_checks.py
+++ b/tests/test_schema_checks.py
@@ -2,7 +2,6 @@ import os
 import pytest
 import test_utils
 from qc_openscenario import constants
-from qc_openscenario.checks.schema_checker import schema_constants
 from qc_baselib import Result, IssueSeverity
 
 
@@ -21,8 +20,7 @@ def test_valid_schema_positive(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
-        len(result.get_issues_by_rule_uid("asam.net:xosc:1.0.0:xml.valid_schema"))
-        == 0
+        len(result.get_issues_by_rule_uid("asam.net:xosc:1.0.0:xml.valid_schema")) == 0
     )
 
     test_utils.cleanup_files()
@@ -43,8 +41,7 @@ def test_valid_schema_negative(
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
     assert (
-        len(result.get_issues_by_rule_uid("asam.net:xosc:1.0.0:xml.valid_schema"))
-        == 0
+        len(result.get_issues_by_rule_uid("asam.net:xosc:1.0.0:xml.valid_schema")) == 0
     )
     test_utils.cleanup_files()
 
@@ -63,13 +60,8 @@ def test_unsupported_schema_version(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    checker_result = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=schema_constants.CHECKER_ID,
-    )
     assert (
-        len(result.get_issues_by_rule_uid("asam.net:xosc:1.0.0:xml.valid_schema"))
-        == 0
+        len(result.get_issues_by_rule_uid("asam.net:xosc:1.0.0:xml.valid_schema")) == 0
     )
     test_utils.cleanup_files()
 
@@ -87,11 +79,6 @@ def test_invalid_schema(
 
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
-
-    checker_result = result.get_checker_result(
-        checker_bundle_name=constants.BUNDLE_NAME,
-        checker_id=schema_constants.CHECKER_ID,
-    )
 
     xml_schema_issues = result.get_issues_by_rule_uid(
         "asam.net:xosc:1.0.0:xml.valid_schema"


### PR DESCRIPTION
**Description**

This refactoring guarantees that one checker contains only one rules. Besides refactoring, many tests are also added to check for the status of the checkers.

**Main changes**

1. Refactor so that each checker contains only one rules
2. Add more unit tests to check the status of the checkers.
3. Fix some unit test data file that doesn't follow the schema properly, leading to skipped checks.

**How was the PR tested?**

1. Unit-test 

**Notes**
